### PR TITLE
Audio Out for Hermes Lite and Hermes Remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 ifeq ($(UNAME_N),odroid)
 GPIOLIBS=-lwiringPi
 endif
-LIBS=-lrt -lm -lwdsp -lpthread $(GTKLIBS) $(GPIOLIBS) $(SOAPYSDRLIBS) $(FREEDVLIBS)
+LIBS=-lrt -lm -lwdsp -lpthread -lpulse-simple -lpulse $(GTKLIBS) $(GPIOLIBS) $(SOAPYSDRLIBS) $(FREEDVLIBS)
 INCLUDES=$(GTKINCLUDES)
 
 COMPILE=$(CC) $(OPTIONS) $(INCLUDES)
@@ -56,6 +56,7 @@ COMPILE=$(CC) $(OPTIONS) $(INCLUDES)
 PROGRAM=pihpsdr
 
 SOURCES= \
+audio.c\
 band.c \
 frequency.c \
 discovered.c \
@@ -85,6 +86,7 @@ wdsp_init.c
 HEADERS= \
 agc.h \
 alex.h \
+audio.h \
 band.h \
 frequency.h \
 bandstack.h \
@@ -113,6 +115,7 @@ xvtr.h
 
 
 OBJS= \
+audio.o \
 band.o \
 frequency.o \
 discovered.o \


### PR DESCRIPTION
Hi John,

This is a quick little modification so that pihpsdr will work with Hermes
Lite and remotely with Hermes.  It plays the audio using pulseaudio on
the display machine.  To remove it you only need to comment out line 52
on old_protocol.c, which should be #define AUDIO_OUT.

You had all the stuff needed set up for the new LimeSDR, so I just added 
calls to audio_write, etc. so it would work for the old_protocol with Hermes 
Lite.  

Thanks for pihpsdr.  It is very nice, and the wdsp engine has some nice features
that it helped me test out.  

73,

Rob
KL7NA