### PR TITLE
Add missing stdint.h includes in 1.2

### DIFF
--- a/agc_menu.c
+++ b/agc_menu.c
@@ -18,6 +18,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/ant_menu.c
+++ b/ant_menu.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/band_menu.c
+++ b/band_menu.c
@@ -18,6 +18,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/bandstack_menu.c
+++ b/bandstack_menu.c
@@ -18,6 +18,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cw_menu.c
+++ b/cw_menu.c
@@ -20,6 +20,7 @@
 #include <gtk/gtk.h>
 #include <semaphore.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/display_menu.c
+++ b/display_menu.c
@@ -20,6 +20,7 @@
 #include <gtk/gtk.h>
 #include <semaphore.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/dsp_menu.c
+++ b/dsp_menu.c
@@ -20,6 +20,7 @@
 #include <gtk/gtk.h>
 #include <semaphore.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/equalizer_menu.c
+++ b/equalizer_menu.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/fft_menu.c
+++ b/fft_menu.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/filter_menu.c
+++ b/filter_menu.c
@@ -16,6 +16,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/meter_menu.c
+++ b/meter_menu.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 

--- a/mode_menu.c
+++ b/mode_menu.c
@@ -18,6 +18,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/oc_menu.c
+++ b/oc_menu.c
@@ -20,6 +20,7 @@
 #include <gtk/gtk.h>
 #include <semaphore.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/radio_menu.c
+++ b/radio_menu.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/rigctl.c
+++ b/rigctl.c
@@ -24,6 +24,7 @@
 #include <gdk/gdk.h>
 #include <unistd.h>
 //#include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "toolbar.h"

--- a/rx_menu.c
+++ b/rx_menu.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/step_menu.c
+++ b/step_menu.c
@@ -18,6 +18,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/store_menu.c
+++ b/store_menu.c
@@ -19,6 +19,7 @@
 */
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/toolbar.c
+++ b/toolbar.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <semaphore.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/transmitter.c
+++ b/transmitter.c
@@ -19,6 +19,7 @@
 
 #include <gtk/gtk.h>
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
In version 1.2, `uintptr_t` is now used to pass parameters to GTK
callbacks, in order to get rid of compiler warnings. However, at least
on some systems, this requires including the `stdint.h` header.