### PR TITLE
Some bug fixes for STEMlab/HAMlab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 # uncomment the line below to include support for STEMlab discovery
 #STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
 
+# uncommment this line for activate work-around some RedPitaty HPSDR bugs
+#STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
+
 #uncomment the line below for the platform being compiled on
 UNAME_N=raspberrypi
 #UNAME_N=odroid
@@ -179,7 +182,9 @@ GTKLIBS=`pkg-config --libs gtk+-3.0`
 AUDIO_LIBS=-lasound
 #AUDIO_LIBS=-lsoundio
 
-OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(USBOZY_OPTIONS) $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) $(FREEDV_OPTIONS) $(LOCALCW_OPTIONS) $(RADIOBERRY_OPTIONS) $(PSK_OPTIONS) $(STEMLAB_OPTIONS) -D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(DEBUG_OPTION) -O3
+OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(USBOZY_OPTIONS) $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) \
+		$(FREEDV_OPTIONS) $(LOCALCW_OPTIONS) $(RADIOBERRY_OPTIONS) $(PSK_OPTIONS) $(STEMLAB_OPTIONS) $(STEMLAB_FIX_OPTION) \
+		-D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(DEBUG_OPTION) -O3
 
 LIBS=-lrt -lm -lwdsp -lpthread $(AUDIO_LIBS) $(USBOZY_LIBS) $(PSKLIBS) $(GTKLIBS) $(GPIO_LIBS) $(SOAPYSDRLIBS) $(FREEDVLIBS) $(STEMLAB_LIBS)
 INCLUDES=$(GTKINCLUDES)

--- a/meter.c
+++ b/meter.c
@@ -232,6 +232,11 @@ if(analog_meter) {
     case SMETER:
       {
       double level=value+(double)adc_attenuation[rx->adc];
+      if (filter_board == CHARLY25) {
+	// preamp/dither encodes the preamp level
+        if (rx->preamp) level -= 18.0;
+        if (rx->dither) level -= 18.0;
+      }
       offset=210.0;
 
       int i;
@@ -529,6 +534,11 @@ if(analog_meter) {
       text_location=10;
       offset=5.0;
       double level=value+(double)adc_attenuation[rx->adc];
+      if (filter_board == CHARLY25) {
+	// preamp/dither encodes the preamp level
+        if (rx->preamp) level -= 18.0;
+        if (rx->dither) level -= 18.0;
+      }
       if(meter_width>=114) {
         //int db=meter_width/114; // S9+60 (9*6)+60
         //if(db>2) db=2;

--- a/rigctl.c
+++ b/rigctl.c
@@ -58,8 +58,8 @@
 #include <sys/socket.h>
 #include <arpa/inet.h> //inet_addr
 
-//#undef RIGCTL_DEBUG
-#define RIGCTL_DEBUG
+#undef RIGCTL_DEBUG
+//#define RIGCTL_DEBUG
 
 int rigctl_port_base=19090;
 int rigctl_enable=0;

--- a/rx_menu.c
+++ b/rx_menu.c
@@ -119,9 +119,8 @@ static void mute_radio_cb(GtkWidget *widget, gpointer data) {
 // call audo_close_output with old device, audio_open_output with new one
 //
 static void local_output_changed_cb(GtkWidget *widget, gpointer data) {
-//active_receiver->audio_device=(int)(long)data;
   int newdev = (int)(long)data;
-fprintf(stderr,"local_output_changed rx=%d from %d to %d\n",active_receiver->id,active_receiver->audio_device,newdev);
+  fprintf(stderr,"local_output_changed rx=%d from %d to %d\n",active_receiver->id,active_receiver->audio_device,newdev);
   if(active_receiver->local_audio) {
     audio_close_output(active_receiver);                     // audio_close with OLD device
     active_receiver->audio_device=newdev;                    // update rx to NEW device
@@ -130,7 +129,10 @@ fprintf(stderr,"local_output_changed rx=%d from %d to %d\n",active_receiver->id,
     } else {
       active_receiver->local_audio=0;
     }
-fprintf(stderr,"local_output_changed rx=%d local_audio=%d\n",active_receiver->id,active_receiver->local_audio);
+    fprintf(stderr,"local_output_changed rx=%d local_audio=%d\n",active_receiver->id,active_receiver->local_audio);
+  } else {
+    // If not (currently) using local audio, just change dev num
+    active_receiver->audio_device=newdev;
   }
 }
 

--- a/sliders.c
+++ b/sliders.c
@@ -217,11 +217,15 @@ static gboolean load_att_type_cb(gpointer data) {
 
 static void c25_att_combobox_changed(GtkWidget *widget, gpointer data) {
   int id = atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
+  //DL1YCF: store attenuation, such that in meter.c the correct level is displayed
+  adc_attenuation[active_receiver->adc] = 12.0*id;
   set_alex_attenuation(id);
 }
 
 static void c25_preamp_combobox_changed(GtkWidget *widget, gpointer data) {
   int id = atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(widget)));
+  //DL1YCF comment: dither and preamp are "misused" to store the PreAmp value.
+  //                this has to be exploited in meter.c
   active_receiver->dither = id >= 2;
   active_receiver->preamp = id >= 1;
 }


### PR DESCRIPTION
Makefile: include support for the STEMLAB_FIX code in old_protocol.c. This is common to Mac and Raspberry versions. The two issuses were a) Hamlab did not start b) CW often did not work.

sliders.c  and meter.c:  correct for ATT/PreAMP when displaying signal strength for CHARLY25 filter board

rigctl.c: de-activate the RIGCTL-DEBUG option since it produces tons of output

rx_menu.c: when changing the RX output device, first close the OLD device then open the NEW one.
This was messed up (it was tried to close the new device first).