### PR TITLE
Finalized CW stuff. "CW engine" without TXAPostGenRun. Local CW now should work.

### DIFF
--- a/discovered.h
+++ b/discovered.h
@@ -77,6 +77,7 @@
 #define STEMLAB_PAVEL_RX 1
 #define STEMLAB_PAVEL_TRX 2
 #define STEMLAB_RP_TRX 4
+#define HAMLAB_RP_TRX 8
 #endif
 
 

--- a/discovery.c
+++ b/discovery.c
@@ -295,9 +295,15 @@ fprintf(stderr,"%p Protocol=%d name=%s\n",d,d->protocol,d->name);
           }
           if ((d->software_version & STEMLAB_RP_TRX) != 0) {
             gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(apps_combobox[i]),
-                "stemlab_sdr_transceiver_hpsdr", "RedPitaya-Trx");
+                "stemlab_sdr_transceiver_hpsdr", "STEMlab-Trx");
             gtk_combo_box_set_active_id(GTK_COMBO_BOX(apps_combobox[i]),
                 "stemlab_sdr_transceiver_hpsdr");
+          }
+          if ((d->software_version & HAMLAB_RP_TRX) != 0) {
+            gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(apps_combobox[i]),
+                "hamlab_sdr_transceiver_hpsdr", "HAMlab-Trx");
+            gtk_combo_box_set_active_id(GTK_COMBO_BOX(apps_combobox[i]),
+                "hamlab_sdr_transceiver_hpsdr");
           }
           gtk_widget_show(apps_combobox[i]);
           gtk_grid_attach(GTK_GRID(grid), apps_combobox[i], 4, i, 1, 1);

--- a/ext.c
+++ b/ext.c
@@ -141,11 +141,15 @@ int ext_radio_change_sample_rate(void *data) {
   return 0;
 }
 
+// DL1YCF: because of the new CW algorithm,
+//         this function is no longer used
 int ext_cw_setup() {
   radio_cw_setup();
   return 0;
 }
 
+// DL1YCF: because of the new CW algorithm,
+//         this function is no longer used
 int ext_cw_key(void *data) {
   radio_cw_key((uintptr_t)data);
   return 0;

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -1218,21 +1218,20 @@ void ozy_send_buffer() {
   } else {
     mode=vfo[0].mode;
   }
-  if(mode==modeCWU || mode==modeCWL) {
+  if (isTransmitting()) {
+    if(mode==modeCWU || mode==modeCWL) {
 //
-//  The default is doing 'external CW', that is,
-//  CW is entirely done on the HPSDR board. In this
-//  case, we should not set MOX, the PTT switching on
-//  the HPSDR board is done by the board itself.
+//    If CW is done on the HPSDR board, we should not set
+//    the MOX bit, everything is done in the FPGA.
 //
-//  However, if we are doing local CW or tuning,
-//  we must put the SDR into TX mode.
+//    However, if we are doing CAT CW, local CW or tuning,
+//    we must put the SDR into TX mode.
 //
-    if(isTransmitting() && (tune || local_cw_is_active)) {
-      output_buffer[C0]|=0x01;
-    }
-  } else {
-    if(isTransmitting()) {
+      if(tune || CAT_cw_is_active || !cw_keyer_internal) {
+        output_buffer[C0]|=0x01;
+      }
+    } else {
+      // not doing CW? set MOX in any case.
       output_buffer[C0]|=0x01;
     }
   }

--- a/radio.c
+++ b/radio.c
@@ -288,7 +288,7 @@ double vox_threshold=0.001;
 double vox_gain=10.0;
 double vox_hang=250.0;
 int vox=0;
-int local_cw_is_active=0;
+int CAT_cw_is_active=0;
 int cw_key_hit=0;
 
 int diversity_enabled=0;
@@ -899,6 +899,8 @@ int getTune() {
   return tune;
 }
 
+// DL1YCF: because of the new CW algorithm,
+//         this function is no longer used
 void radio_cw_setup() {
   int mode=vfo[VFO_A].mode;;
   if(split) {
@@ -912,6 +914,8 @@ void radio_cw_setup() {
   SetTXAPostGenToneMag(transmitter->id,0.99999);
 }
 
+// DL1YCF: because of the new CW algorithm,
+//         this function is no longer used
 void radio_cw_key(int state) {
   SetTXAPostGenRun(transmitter->id,state);
 }

--- a/radio.h
+++ b/radio.h
@@ -244,7 +244,7 @@ extern double vox_threshold;
 extern double vox_gain;
 extern double vox_hang;
 extern int vox;
-extern int local_cw_is_active;
+extern int CAT_cw_is_active;
 extern int cw_key_hit;
 
 extern int diversity_enabled;

--- a/rigctl.c
+++ b/rigctl.c
@@ -495,11 +495,10 @@ static gpointer rigctl_cw_thread(gpointer data)
     dashlen = (dotlen * 3 * cw_keyer_weight) / 50L;
     dotsamples = 57600 / cw_keyer_speed;
     dashsamples = (3456 * cw_keyer_weight) / cw_keyer_speed;
-    local_cw_is_active=1;
+    CAT_cw_is_active=1;
     if (!mox) {
 	// activate PTT
         g_idle_add(ext_ptt_update ,(gpointer)1);
-        g_idle_add(ext_cw_key     ,(gpointer)1);
 	// have to wait until it is really there
         while (!mox) usleep(50000L);
 	// some extra time to settle down
@@ -514,8 +513,7 @@ static gpointer rigctl_cw_thread(gpointer data)
        // CW transmission has been aborted, either due to manually
        // removing MOX, changing the mode to non-CW, or because a CW key has been hit.
        // Do not remove PTT if we abort CAT CW because a CW key has been hit.
-       local_cw_is_active=0;
-       g_idle_add(ext_cw_key     ,(gpointer)0);
+       CAT_cw_is_active=0;
        // If an external CW key has been hit, we continue in TX mode
        // doing CW manually. Otherwise, switch PTT off.
        if (!cw_key_hit) {
@@ -536,8 +534,7 @@ static gpointer rigctl_cw_thread(gpointer data)
       // Otherwise remove PTT and wait for next CAT
       // CW command.
       if (cw_busy) continue;
-      local_cw_is_active=0;
-      g_idle_add(ext_cw_key     ,(gpointer)0);
+      CAT_cw_is_active=0;
       g_idle_add(ext_ptt_update ,(gpointer)0);
     }
   }
@@ -547,7 +544,6 @@ static gpointer rigctl_cw_thread(gpointer data)
   // of a transmission
   rigctl_cw_thread_id = NULL;
   cw_busy=0;
-  g_idle_add(ext_cw_key     ,(gpointer)0);
   g_idle_add(ext_ptt_update ,(gpointer)0);
   return NULL;
 }
@@ -1754,7 +1750,6 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
                                                      sprintf(msg,"ZZFB%011lld;",vfo[VFO_B].frequency);
                                                   }
                                                }
-                                               fprintf(stderr,"RIGCTL: FB=%s\n",msg);
                                                send_resp(client_sock,msg);
                                             }
                                          }
@@ -2175,11 +2170,7 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
 					    // - Note further that the space immediately following "KY" is *not*
 					    //   part of the message.
 					    if (!cw_busy && len > 3) {
-						// A CW text will be sent. We have to call cw_setup here because
-						// TUNE changes the WDSP side tone frequency, and in this case we have
-						// to re-adjust it.
-					        g_idle_add(ext_cw_setup,NULL);    // Initialize for external transmit
-						// Copy data to buffer
+						// A CW text will be sent. Copy incoming data to buffer
 						strncpy(cw_buf, cmd_input+3, 29);
 						// Kenwood protocol allows for at most 24 characters, so
 						// this seems pure paranoia -- but who knows?
@@ -3223,13 +3214,8 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
         else if(strcmp(cmd_str,"SM")==0) {  
                                             // PiHPSDR - ZZSM - Read SMeter - same range as TS 2000
                                             // TI-2000 - SM - Read SMETER
-                                            // SMx;  x=0 RX1, x=1 RX2 
-                                            // meter is in dbm - value will be 0<260
-                                            // Translate to 00-30 for main, 0-15 fo sub
-                                            // Resp= SMxAABB; 
-                                            //  Received range from the SMeter can be -127 for S0, S9 is -73, and S9+60=-13.;
-                                            //  PowerSDR returns S9=0015 code. 
-                                            //  Let's make S9 half scale or a value of 70.  
+                                            // SM0:  main receiver, SM1: sub receiver
+                                            // Resp= SM0xxxx or SM1yyyy; xxxx between 0000 and 0030, yyyy between 0000 and 0015.
                                             double level=0.0;
 
                                             int r=0;
@@ -3242,23 +3228,38 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
                                             }
                                             level = GetRXAMeter(receiver[r]->id, smeter); 
 
-                                            // Determine how high above 127 we are..making a range of 114 from S0 to S9+60db
-                                            // 5 is a fugdge factor that shouldn't be there - but seems to get us to S9=SM015
-					    // DL1YCF replaced abs by fabs, and changed 127 to floating point constant
-                                            level =  fabs(127.0+(level + (double) adc_attenuation[receiver[r]->adc]))+5;
-                                         
-                                            // Clip the value just in case
-                                            if(cmd_input[2] == '0') { 
-                                               new_level = (int) ((level * 30.0)/114.0);
-                                               // Do saturation check
-                                               if(new_level < 0) { new_level = 0; }
-                                               if(new_level > 30) { new_level = 30;}
-                                            } else { //Assume we are using sub receiver where range is 0-15
-                                               new_level = (int) ((level * 15.0)/114.0);
-                                               // Do saturation check
-                                               if(new_level < 0) { new_level = 0; }
-                                               if(new_level > 15) { new_level = 15;}
-                                            }
+                                            if(r == 0) { 
+						// DL1YCF: In the "main" bar graph, each bar counts 4 dB.
+						// S9+60 has 30 bars, S9 has 15 bars, S7 has 12 bars, and so on
+						// since S9 is about -73 dBm, the correct formula for converting
+						// dBm to bars is 15 + (level+73)/4 or 0.25*level + 33.25.
+						// The problem is now that S1 has 3 bars, such that 0 bars would
+						// correspond to S0 - 6dB. If one assumes that S0 corresponds
+						// to 0 bars, then it follows that the slope is 2 dB per bar
+						// below S1. This assumption is used in hamlib, and thus followed here.
+						if (level <= -121.0) {
+						    new_level = (int) round(0.50*level+63.50);   // valid up to S1 = -48 dBm
+						} else {
+						    new_level = (int) round(0.25*level+33.25);   // valid if at least S1
+						}
+						// Clip
+						if(new_level < 0) { new_level = 0; }
+						if(new_level > 30) { new_level = 30;}
+                                            } else {
+						// DL1YCF: studying the pictures in the TS2000 manual,
+						// for the "sub" display we have 0-9 small bars for S0 -S9, and in addition 1-6
+						// large bars for S9+10, ..., S9+60. So the slope is 6 dB per par
+						// up to S9, and 10 dB per bar beyond.
+						if (level <= -73.0) {
+						    new_level = (int) round(0.16667*level+21.16667);   // valid up to S9
+						} else {
+						    new_level = (int) round(0.1*level+16.3);           // valid if at least S9
+						}
+						// Clip
+						if(new_level < 0) { new_level = 0; }
+						if(new_level > 15) { new_level = 15;}
+					    }
+
                                             if(zzid_flag == 0) {
                                                sprintf(msg,"SM%1c%04d;",
                                                            cmd_input[2],new_level);
@@ -3517,7 +3518,6 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
                                                g_idle_add(ext_mox_update,(gpointer)(long)mox_state); 
                                                g_idle_add(ext_vfo_update,NULL);
                                             } else {
-                                              g_idle_add(ext_cw_setup,NULL);    // Initialize for external transmit
                                               g_idle_add(ext_mox_update,(gpointer)(long)1); // Turn on External MOX
                                             }
                                          }
@@ -3682,17 +3682,19 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
                                              }
                                          }
         else if((strcmp(cmd_str,"XC")==0) && (zzid_flag == 1)) {  
-                                            // PiHPSDR - ZZXC  - Turn off External MOX- 
-                                            g_idle_add(ext_mox_update,(gpointer)(long)0); // Turn on xmitter (set Mox)
+                                            // PiHPSDR - ZZXC  - Terminate "CW" via ZZXO/ZZXT (Key up and MOX off)
+					    cw_hold_key(0);
+                                            g_idle_add(ext_mox_update,(gpointer)(long)0);
+					    CAT_cw_is_active=0;
                                          }
         else if((strcmp(cmd_str,"XI")==0) && (zzid_flag == 1)) {  
-                                            // PiHPSDR - ZZXI - Initialize the transmitter for external CW
-                                            g_idle_add(ext_cw_setup,NULL);    // Initialize for external transmit
-                                            g_idle_add(ext_mox_update,(gpointer)(long)1); // Turn on External MOX
+                                            // PiHPSDR - ZZXI - Prepeare for "CW" via ZZXO/ZZXT (MOX on)
+					    CAT_cw_is_active=1;
+                                            g_idle_add(ext_mox_update,(gpointer)(long)1);
                                          }
        else if((strcmp(cmd_str,"XO")==0) && (zzid_flag == 1)) {  
-                                            // PiHPSDR - ZZXT - Turn CW Note off when in CW mode
-                                            g_idle_add(ext_cw_key, (gpointer)(long)0);
+                                            // PiHPSDR - ZZXO - Turn CW Note off when in CW mode
+					    cw_hold_key(0);
                                          }
         else if(strcmp(cmd_str,"XT")==0) {  
                                            if(zzid_flag == 0 ) {
@@ -3703,7 +3705,7 @@ void parse_cmd ( char * cmd_input,int len,int client_sock) {
                                              }
                                            } else {
                                             // PiHPSDR - ZZXT - Turn CW Note on when in CW mode
-                                            g_idle_add(ext_cw_key, (gpointer)(long)1);
+					    cw_hold_key(1);
                                            }
                                          }
         else if((strcmp(cmd_str,"XX")==0) && (zzid_flag == 0)) {  // 

--- a/rigctl.c
+++ b/rigctl.c
@@ -496,6 +496,14 @@ static gpointer rigctl_cw_thread(gpointer data)
     dotsamples = 57600 / cw_keyer_speed;
     dashsamples = (3456 * cw_keyer_weight) / cw_keyer_speed;
     CAT_cw_is_active=1;
+    // if out-of-band, ptt_update() has no effect
+    // and mox will not appear. In this case, we should
+    // skip the pending CW message to avoid an infinite
+    // loop
+    if (!canTransmit() && ! tx_out_of_band) {
+	fprintf(stderr,"CAT CW skipped -- out of band.\n");
+	continue;
+    }
     if (!mox) {
 	// activate PTT
         g_idle_add(ext_ptt_update ,(gpointer)1);

--- a/rigctl.c
+++ b/rigctl.c
@@ -413,6 +413,8 @@ void rigctl_send_cw_char(char cw_char) {
        case 'W': strcpy(pattern,".--"); break;
        case 'x': 
        case 'X': strcpy(pattern,"-..-"); break;
+       case 'y':
+       case 'Y': strcpy(pattern,"-.--"); break;
        case 'z': 
        case 'Z': strcpy(pattern,"--.."); break;
        case '0': strcpy(pattern,"-----"); break;

--- a/stemlab_discovery.c
+++ b/stemlab_discovery.c
@@ -268,6 +268,10 @@ static size_t app_list_cb(void *buffer, size_t size, size_t nmemb, void *data) {
   if (g_strstr_len(buffer, size*nmemb, rp_trx_json) != NULL) {
     *software_version |= STEMLAB_RP_TRX;
   }
+  const gchar *hamlab_trx_json = "\"hamlab_sdr_transceiver_hpsdr\":";
+  if (g_strstr_len(buffer, size*nmemb, hamlab_trx_json) != NULL) {
+    *software_version |= HAMLAB_RP_TRX;
+  }
   // Returning the total amount of bytes "processed" to signal cURL that we
   // are done without any errors
   return size * nmemb;

--- a/transmitter.h
+++ b/transmitter.h
@@ -145,7 +145,7 @@ extern void transmitter_set_compressor(TRANSMITTER *tx,int state);
 extern void tx_set_ps_sample_rate(TRANSMITTER *tx,int rate);
 extern void add_ps_iq_samples(TRANSMITTER *tx, double i_sample_0,double q_sample_0, double i_sample_1, double q_sample_1);
 
-extern void cw_sidetone_mute(int mute);
+extern void cw_hold_key(int state);
 #endif
 
 


### PR DESCRIPTION
This is the last of the big steps to get CW state-of-the art. Now "local CW" should work. The problem was when and how to stop carrier generation. The solution is to bypass WDSP, it is not necessary here: a zero frequency signal produces I/Q samples where all I=1 and all Q=0. Therefore, what has to be
sent to the SDR is simply the CW envelope in the I samples and zero in the Q samples. Thus,
TXAPostGen ist not needed for doing CW.

I still generate the I/Q samples in tx->iq_output_buffer manually for the sole purpose of
seeing the spectrum of your CW signal. So if you go back to "hard pulses", you will see this
immediately on your TX spectrum display. tx->iq_output_buffer is *not used* for generating
the I/Q samples for CW transmit.

Note that this makes the functions ext_cw_setup, ext_cw_key, radio_cw_setup and radio_cw_key
obsolete (no longer used).

Local CW (in iambic.c) should now work. If SIDETONE_GPIO is nonzero, a local side tone is produces (as intended) but cw_hold_key() is now called in any case (you do not want to get a side tone but no signal). If a CW key is hit, this is now also reported (by setting cw_key_hit) so you can abort running CAT CW messages by hitting your local CW key. I have also assured that the MOX bit is set in the SDR if doing local CW.

I cannot test local CW, but I can verify that I can "key" the SDR using the CAT commands
ZZXC (CW off), ZZXI (CW on), ZZXO (key up) and ZZXT (key down).

In rigctl, I fixed the S-meter reading (SM0 and SM1 command) since I by accident came across. I have recently fixed this "on the other side" in hamlib for the TS590, so I was familiar with the
problem.

Some changes are simply due to finding better names. The function cw_sidetone_mute()
is really cw_hold_key (it keys CW in the transmitter), and the variable local_cw_is_active
now reads CAT_cw_is_active because "local CW" is detected by the variable
cw_keyer_internal.

This pull request should finalize the major overhaul of the CW engine in piHPSDR,
except for small possible issues that may occur in field testing local CW (which I cannot
do, I run piHPSDR on my Macintosh).

ADDED:  cw_audio_write() now also fixed in ALSA module audio.c, using the same trick
as in the portaudio part.

ADDED: stemlab_discovery now also correctly detects and starts the HPSDR application on HAMlab boxes, where the app is named hamlab_sdr_transceiver_hpsdr instead of stemlab_transceiver_hpsdr.
