### PR TITLE
LOCALCW, PURESIGNAL, STEMLAB_DISCOVERY without AVAHI working now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 # uncomment the line below to include support for STEMlab discovery (WITHOUT AVAHI)
 #STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_NOAVAHI
 
-# uncommment this line for activate work-around some RedPitaty HPSDR bugs
+# uncommment this line for circumventing problems with RedPitya HPSDR apps.
 #STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 
 #uncomment the line below for the platform being compiled on (actually not used)

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ endif
 
 ifeq ($(GPIO_INCLUDE),GPIO)
   GPIO_OPTIONS=-D GPIO
-  GPIO_LIBS=-lwiringPi -lpigpio 
+  GPIO_LIBS=-lwiringPi
   GPIO_SOURCES= \
   gpio.c \
   encoder_menu.c

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,12 @@ UNAME_N=raspberrypi
 #UNAME_N=jetsen
 
 # Additional options that can be chosen at compile time:
-# -DSPLIT_RXTX          if there is more than one receiver, TX panel only "hides" the first one
 # -DPROTOCOL_DEBUG      logs (on stderr) all state changes sent to the SDR (only old protocol)
 # -DDEBUG               activate general debug output
 #
 # leave the list empty if no such option should be used
 
-ADDITIONAL_OPTIONS=
+DEBUGL_OPTION=
 
 
 CC=gcc
@@ -206,7 +205,7 @@ AUDIO_LIBS=-lasound
 
 OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(USBOZY_OPTIONS) $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) \
 		$(FREEDV_OPTIONS) $(LOCALCW_OPTIONS) $(RADIOBERRY_OPTIONS) $(PSK_OPTIONS) $(STEMLAB_OPTIONS) $(STEMLAB_FIX_OPTION) \
-		-D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(ADDITIONAL_OPTIONS) -O3
+		-D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(DEBUG_OPTION) -O3
 
 LIBS=-lrt -lm -lwdsp -lpthread $(AUDIO_LIBS) $(USBOZY_LIBS) $(PSKLIBS) $(GTKLIBS) $(GPIO_LIBS) $(SOAPYSDRLIBS) $(FREEDVLIBS) $(STEMLAB_LIBS)
 INCLUDES=$(GTKINCLUDES)

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,9 @@ UNAME_N=raspberrypi
 #UNAME_N=jetsen
 
 # Additional options that can be chosen at compile time:
-# -DDIGI_MODES          wide filters and no noise reduction in DIGU/DIGL
 # -DSPLIT_RXTX          if there is more than one receiver, TX panel only "hides" the first one
 # -DPROTOCOL_DEBUG      logs (on stderr) all state changes sent to the SDR (only old protocol)
-# -DDEBUG               activate debug output
+# -DDEBUG               activate general debug output
 #
 # leave the list empty if no such option should be used
 

--- a/Makefile
+++ b/Makefile
@@ -27,33 +27,27 @@ GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 # uncomment the line to below include support local CW keyer
 #LOCALCW_INCLUDE=LOCALCW
 
-# uncomment the line below to include support for STEMlab discovery (with avahi)
+# uncomment the line below to include support for STEMlab discovery (WITH AVAHI)
 #STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
 
-# uncomment the line below to include support for STEMlab discovery WITHOUT AVAHI
+# uncomment the line below to include support for STEMlab discovery (WITHOUT AVAHI)
 #STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_NOAVAHI
 
 # uncommment this line for activate work-around some RedPitaty HPSDR bugs
 #STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 
-#uncomment the line below for the platform being compiled on
+#uncomment the line below for the platform being compiled on (actually not used)
 UNAME_N=raspberrypi
 #UNAME_N=odroid
 #UNAME_N=up
 #UNAME_N=pine64
 #UNAME_N=jetsen
 
-# Additional options that can be chosen at compile time:
-# -DPROTOCOL_DEBUG      logs (on stderr) all state changes sent to the SDR (only old protocol)
-# -DDEBUG               activate general debug output
-#
-# leave the list empty if no such option should be used
-
-DEBUGL_OPTION=
-
-
 CC=gcc
 LINK=gcc
+
+# uncomment the line below for various debug facilities
+#DEBUG_OPTION=-D DEBUG
 
 ifeq ($(PURESIGNAL_INCLUDE),PURESIGNAL)
 PURESIGNAL_OPTIONS=-D PURESIGNAL
@@ -176,8 +170,10 @@ ifeq ($(I2C_INCLUDE),I2C)
 endif
 
 #
-# We have two versions here, the second one has to be used
-# if you do not have the avahi libraries
+# We have two versions of STEMLAB_DISCOVERY here,
+# the second one has to be used
+# if you do not have the avahi (devel-) libraries
+# on your system.
 #
 ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY)
 STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY \

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -44,14 +44,13 @@ UNAME_N=raspberrypi
 #UNAME_N=jetsen
 
 # Additional options that can be chosen at compile time:
-# -DDIGI_MODES		wide filters and no noise reduction in DIGU/DIGL
 # -DSPLIT_RXTX          if there is more than one receiver, TX panel only "hides" the first one
 # -DPROTOCOL_DEBUG	logs (on stderr) all state changes sent to the SDR (only old protocol)
 # -DDEBUG		activate debug output
 #
 # leave the list empty if no such option should be used
 
-ADDITIONAL_OPTIONS= -DDIGI_MODES -DSPLIT_RXTX
+ADDITIONAL_OPTIONS= -DSPLIT_RXTX
 
 CC=gcc
 LINK=gcc

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -44,13 +44,12 @@ UNAME_N=raspberrypi
 #UNAME_N=jetsen
 
 # Additional options that can be chosen at compile time:
-# -DSPLIT_RXTX          if there is more than one receiver, TX panel only "hides" the first one
 # -DPROTOCOL_DEBUG	logs (on stderr) all state changes sent to the SDR (only old protocol)
 # -DDEBUG		activate debug output
 #
 # leave the list empty if no such option should be used
 
-ADDITIONAL_OPTIONS= -DSPLIT_RXTX
+DEBUG_OPTION=
 
 CC=gcc
 LINK=gcc
@@ -210,7 +209,7 @@ AUDIO_LIBS=-lportaudio
 
 OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(USBOZY_OPTIONS) $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) \
                 $(FREEDV_OPTIONS) $(LOCALCW_OPTIONS) $(RADIOBERRY_OPTIONS) $(PSK_OPTIONS) $(STEMLAB_OPTIONS) $(STEMLAB_FIX_OPTION) \
-                -D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(PORTAUDIO_OPTIONS) $(ADDITIONAL_OPTIONS) -O3
+                -D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(PORTAUDIO_OPTIONS) $(DEBUG_OPTION) -O3
 
 LIBS=-lm -lwdsp -lpthread $(AUDIO_LIBS) $(USBOZY_LIBS) $(PSKLIBS) $(GTKLIBS) $(GPIO_LIBS) $(SOAPYSDRLIBS) $(FREEDVLIBS) $(STEMLAB_LIBS)
 INCLUDES=$(GTKINCLUDES)

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -27,29 +27,21 @@ PURESIGNAL_INCLUDE=PURESIGNAL
 # uncomment the line to below include support local CW keyer
 #LOCALCW_INCLUDE=LOCALCW
 
-# uncomment the line below to include support for STEMlab discovery (with avahi)
-#STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
-
-# uncomment the line below to include support for STEMlab discovery WITHOUT AVAHI
+# uncomment the line below to include support for STEMlab discovery (WITHOUT AVAHI)
 STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_NOAVAHI
 
 # un-commment this line for activate work-around some RedPitaty HPSDR bugs
 STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 
-#uncomment the line below for the platform being compiled on
+#uncomment the line below for the platform being compiled on (actually not used)
 UNAME_N=raspberrypi
 #UNAME_N=odroid
 #UNAME_N=up
 #UNAME_N=pine64
 #UNAME_N=jetsen
 
-# Additional options that can be chosen at compile time:
-# -DPROTOCOL_DEBUG	logs (on stderr) all state changes sent to the SDR (only old protocol)
-# -DDEBUG		activate debug output
-#
-# leave the list empty if no such option should be used
-
-DEBUG_OPTION=
+# uncomment the line below for various debug facilities
+#DEBUG_OPTION=-D DEBUG
 
 CC=gcc
 LINK=gcc
@@ -173,20 +165,6 @@ ifeq ($(I2C_INCLUDE),I2C)
   I2C_SOURCES=i2c.c
   I2C_HEADERS=i2c.h
   I2C_OBJS=i2c.o
-endif
-
-#
-# We have two versions here, the second one has to be used
-# if you do not have the avahi libraries
-#
-ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY)
-STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY \
-  `pkg-config --cflags avahi-gobject` \
-  `pkg-config --cflags libcurl`
-STEMLAB_LIBS=`pkg-config --libs avahi-gobject` `pkg-config --libs libcurl`
-STEMLAB_SOURCES=stemlab_discovery.c
-STEMLAB_HEADERS=stemlab_discovery.h
-STEMLAB_OBJS=stemlab_discovery.o
 endif
 
 ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY_NOAVAHI)
@@ -493,12 +471,19 @@ app:	$(OBJS) $(REMOTE_OBJS) $(USBOZY_OBJS) $(LIMESDR_OBJS) $(FREEDV_OBJS) \
 	@cp MacOS/hpsdr.icns pihpsdr.app/Contents/Resources/hpsdr.icns
 	@cp MacOS/pihpsdr.sh pihpsdr.app/Contents/MacOS/pihpsdr
 	@cp MacOS/hpsdr.png pihpsdr.app/Contents/Resources
-	@for lib in `otool -L pihpsdr.app/Contents/MacOS/pihpsdr-bin | grep dylib | sed -e "s/ (.*//" | grep -Ev "/(usr/lib|System)" | grep -Ev /libg `; do \
+	@for lib in `otool -L pihpsdr.app/Contents/MacOS/pihpsdr-bin | grep dylib | sed -e "s/ (.*//" | grep -Ev "/(usr/lib|System)" | grep -Ev /libg  | grep -Ev pango | grep -Ev cairo`; do \
 	  libfn="`basename $$lib`"; \
 	  cp "$$lib" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
 	  chmod u+w "pihpsdr.app/Contents/Frameworks/$$libfn"; \
 	  install_name_tool -id "@executable_path/../Frameworks/$libfn" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
 	  install_name_tool -change "$$lib" "@executable_path/../Frameworks/$$libfn" pihpsdr.app/Contents/MacOS/pihpsdr-bin; \
 	done
+#
+# Make "app" and copy wdspWisdom and props file to app bundle
+#
+localapp:	app
+	cp wdspWisdom pihpsdr.app/Contents/Resources
+	cp *.props    pihpsdr.app/Contents/Resources
+
 #############################################################################
 

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -3,9 +3,6 @@
 GIT_DATE := $(firstword $(shell git --no-pager show --date=short --format="%ai" --name-only))
 GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 
-# un-commment this line for activate work-around some RedPitaty HPSDR bugs
-STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
-
 # uncomment the line below to include GPIO
 #GPIO_INCLUDE=GPIO
 
@@ -30,12 +27,17 @@ STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 # uncomment the line to below include support local CW keyer
 #LOCALCW_INCLUDE=LOCALCW
 
-# uncomment the line below to include support for STEMlab discovery
-STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
+# uncomment the line below to include support for STEMlab discovery (with avahi)
+#STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
+
+# uncomment the line below to include support for STEMlab discovery WITHOUT AVAHI
+STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_NOAVAHI
+
+# un-commment this line for activate work-around some RedPitaty HPSDR bugs
+STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 
 #uncomment the line below for the platform being compiled on
-UNAME_N=MacOS
-#UNAME_N=raspberrypi
+UNAME_N=raspberrypi
 #UNAME_N=odroid
 #UNAME_N=up
 #UNAME_N=pine64
@@ -45,25 +47,14 @@ UNAME_N=MacOS
 # -DDIGI_MODES		wide filters and no noise reduction in DIGU/DIGL
 # -DSPLIT_RXTX          if there is more than one receiver, TX panel only "hides" the first one
 # -DPROTOCOL_DEBUG	logs (on stderr) all state changes sent to the SDR (only old protocol)
+# -DDEBUG		activate debug output
 #
 # leave the list empty if no such option should be used
 
 ADDITIONAL_OPTIONS= -DDIGI_MODES -DSPLIT_RXTX
 
 CC=gcc
-
-ifeq ($(UNAME_N),MacOS)
-#
-# This is only necessary for "make app", since the "patched"
-# library names are longer
-#
-LINK=gcc -headerpad_max_install_names
-else
 LINK=gcc
-endif
-
-# uncomment the line below for various debug facilities
-#DEBUG_OPTION=-D DEBUG
 
 ifeq ($(PURESIGNAL_INCLUDE),PURESIGNAL)
 PURESIGNAL_OPTIONS=-D PURESIGNAL
@@ -102,7 +93,7 @@ endif
 # uncomment the line below for LimeSDR (uncomment line below)
 #LIMESDR_INCLUDE=LIMESDR
 
-# uncomment the line below when Radioberry radio cape is plugged in
+# uncomment the line below when Radioberry radio cape is plugged in (for now use emulator and old protocol)
 #RADIOBERRY_INCLUDE=RADIOBERRY
 
 ifeq ($(RADIOBERRY_INCLUDE),RADIOBERRY)
@@ -187,9 +178,20 @@ ifeq ($(I2C_INCLUDE),I2C)
 endif
 
 #
-# Here in Makefile.mac, we use the version that does not need avahi
+# We have two versions here, the second one has to be used
+# if you do not have the avahi libraries
 #
 ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY)
+STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY \
+  `pkg-config --cflags avahi-gobject` \
+  `pkg-config --cflags libcurl`
+STEMLAB_LIBS=`pkg-config --libs avahi-gobject` `pkg-config --libs libcurl`
+STEMLAB_SOURCES=stemlab_discovery.c
+STEMLAB_HEADERS=stemlab_discovery.h
+STEMLAB_OBJS=stemlab_discovery.o
+endif
+
+ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY_NOAVAHI)
 STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY -D NO_AVAHI `pkg-config --cflags libcurl`
 STEMLAB_LIBS=`pkg-config --libs libcurl`
 STEMLAB_SOURCES=stemlab_discovery.c
@@ -207,15 +209,11 @@ GTKLIBS=`pkg-config --libs gtk+-3.0`
 PORTAUDIO_OPTIONS=-DPORTAUDIO
 AUDIO_LIBS=-lportaudio
 
-OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(RADIOBERRY_OPTIONS) \
-	$(USBOZY_OPTIONS)  $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) $(FREEDV_OPTIONS) \
-	$(LOCALCW_OPTIONS) $(PSK_OPTIONS)  $(STEMLAB_OPTIONS) $(STEMLAB_FIX_OPTION) \
-	$(PORTAUDIO_OPTIONS) $(ADDITIONAL_OPTIONS) \
-	-D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(DEBUG_OPTION) -O3
+OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(USBOZY_OPTIONS) $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) \
+                $(FREEDV_OPTIONS) $(LOCALCW_OPTIONS) $(RADIOBERRY_OPTIONS) $(PSK_OPTIONS) $(STEMLAB_OPTIONS) $(STEMLAB_FIX_OPTION) \
+                -D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(PORTAUDIO_OPTIONS) $(ADDITIONAL_OPTIONS) -O3
 
-LIBS=   $(AUDIO_LIBS) $(USBOZY_LIBS) $(PSKLIBS) $(GTKLIBS) $(GPIO_LIBS) \
-	$(SOAPYSDRLIBS) $(FREEDVLIBS) $(STEMLAB_LIBS) -lwdsp -lm -pthread
-
+LIBS=-lm -lwdsp -lpthread $(AUDIO_LIBS) $(USBOZY_LIBS) $(PSKLIBS) $(GTKLIBS) $(GPIO_LIBS) $(SOAPYSDRLIBS) $(FREEDVLIBS) $(STEMLAB_LIBS)
 INCLUDES=$(GTKINCLUDES)
 
 COMPILE=$(CC) $(OPTIONS) $(INCLUDES)
@@ -480,7 +478,13 @@ release: $(PROGRAM)
 #       this is then stored *within* the app bundle.
 #
 #############################################################################
-app:  pihpsdr
+app:	$(OBJS) $(REMOTE_OBJS) $(USBOZY_OBJS) $(LIMESDR_OBJS) $(FREEDV_OBJS) \
+		$(LOCALCW_OBJS) $(I2C_OBJS) $(GPIO_OBJS) $(PSK_OBJS) \
+		$(PURESIGNAL_OBJS) $(STEMLAB_OBJS)
+	$(LINK) -headerpad_max_install_names -o $(PROGRAM) $(OBJS) $(REMOTE_OBJS) \
+		$(USBOZY_OBJS) $(I2C_OBJS) $(GPIO_OBJS) $(LIMESDR_OBJS) \
+		$(FREEDV_OBJS) $(LOCALCW_OBJS) $(PSK_OBJS) $(PURESIGNAL_OBJS) \
+		$(STEMLAB_OBJS) $(LIBS)
 	@rm -rf pihpsdr.app
 	@mkdir -p pihpsdr.app/Contents/MacOS
 	@mkdir -p pihpsdr.app/Contents/Frameworks

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -30,7 +30,7 @@ PURESIGNAL_INCLUDE=PURESIGNAL
 # uncomment the line below to include support for STEMlab discovery (WITHOUT AVAHI)
 STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_NOAVAHI
 
-# un-commment this line for activate work-around some RedPitaty HPSDR bugs
+# uncommment this line for circumventing problems with RedPitya HPSDR apps.
 STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 
 #uncomment the line below for the platform being compiled on (actually not used)

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -19,7 +19,7 @@ GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 #FREEDV_INCLUDE=FREEDV
 
 # uncomment the line below to include Pure Signal support
-#PURESIGNAL_INCLUDE=PURESIGNAL
+PURESIGNAL_INCLUDE=PURESIGNAL
 
 # uncomment the line to below include support for sx1509 i2c expander
 #SX1509_INCLUDE=sx1509

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -30,11 +30,8 @@ STEMLAB_FIX_OPTION=-DSTEMLAB_FIX
 # uncomment the line to below include support local CW keyer
 #LOCALCW_INCLUDE=LOCALCW
 
-# uncomment the line below to include support for STEMlab discovery (does not work on MacOS)
-#STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
-
-# uncomment the line below to include support for stripped-down STEMlab discovery that works on MacOS
-STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_MAC
+# uncomment the line below to include support for STEMlab discovery
+STEMLAB_DISCOVERY=STEMLAB_DISCOVERY
 
 #uncomment the line below for the platform being compiled on
 UNAME_N=MacOS
@@ -43,6 +40,15 @@ UNAME_N=MacOS
 #UNAME_N=up
 #UNAME_N=pine64
 #UNAME_N=jetsen
+
+# Additional options that can be chosen at compile time:
+# -DDIGI_MODES		wide filters and no noise reduction in DIGU/DIGL
+# -DSPLIT_RXTX          if there is more than one receiver, TX panel only "hides" the first one
+# -DPROTOCOL_DEBUG	logs (on stderr) all state changes sent to the SDR (only old protocol)
+#
+# leave the list empty if no such option should be used
+
+ADDITIONAL_OPTIONS= -DDIGI_MODES -DSPLIT_RXTX
 
 CC=gcc
 
@@ -181,21 +187,11 @@ ifeq ($(I2C_INCLUDE),I2C)
 endif
 
 #
-# STEMLAB_DISCOVERY_MAC depends on curl but not on avahi
+# Here in Makefile.mac, we use the version that does not need avahi
 #
-ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY_MAC)
-STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY `pkg-config --cflags libcurl`
-STEMLAB_LIBS=`pkg-config --libs libcurl`
-STEMLAB_SOURCES=stemlab_discovery.c
-STEMLAB_HEADERS=stemlab_discovery.h
-STEMLAB_OBJS=stemlab_discovery.o
-endif
-
 ifeq ($(STEMLAB_DISCOVERY), STEMLAB_DISCOVERY)
-STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY \
-  `pkg-config --cflags avahi-gobject` \
-  `pkg-config --cflags libcurl`
-STEMLAB_LIBS=`pkg-config --libs avahi-gobject` `pkg-config --libs libcurl`
+STEMLAB_OPTIONS=-D STEMLAB_DISCOVERY -D NO_AVAHI `pkg-config --cflags libcurl`
+STEMLAB_LIBS=`pkg-config --libs libcurl`
 STEMLAB_SOURCES=stemlab_discovery.c
 STEMLAB_HEADERS=stemlab_discovery.h
 STEMLAB_OBJS=stemlab_discovery.o
@@ -214,7 +210,7 @@ AUDIO_LIBS=-lportaudio
 OPTIONS=-g -Wno-deprecated-declarations $(PURESIGNAL_OPTIONS) $(REMOTE_OPTIONS) $(RADIOBERRY_OPTIONS) \
 	$(USBOZY_OPTIONS)  $(I2C_OPTIONS) $(GPIO_OPTIONS) $(LIMESDR_OPTIONS) $(FREEDV_OPTIONS) \
 	$(LOCALCW_OPTIONS) $(PSK_OPTIONS)  $(STEMLAB_OPTIONS) $(STEMLAB_FIX_OPTION) \
-	$(PORTAUDIO_OPTIONS) \
+	$(PORTAUDIO_OPTIONS) $(ADDITIONAL_OPTIONS) \
 	-D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(DEBUG_OPTION) -O3
 
 LIBS=   $(AUDIO_LIBS) $(USBOZY_LIBS) $(PSKLIBS) $(GTKLIBS) $(GPIO_LIBS) \

--- a/audio.c
+++ b/audio.c
@@ -364,8 +364,16 @@ int audio_write(RECEIVER *rx,short left_sample,short right_sample) {
   snd_pcm_sframes_t delay;
   int error;
   long trim;
-
-  if (rx == active_receiver && isTransmitting()) return;
+  int mode=transmitter->mode;
+  //
+  // We have to stop the stream here if a CW side tone may occur.
+  // This might cause underflows, but we cannot use audio_write
+  // and cw_audio_write simultaneously on the same device.
+  // Instead, the side tone version will take over.
+  // If *not* doing CW, the stream continues because we might wish
+  // to listen to this rx while transmitting.
+  //
+  if (rx == active_receiver && isTransmitting() && (mode==modeCWU || mode==modeCWL)) return 0;
 
   if(rx->playback_handle!=NULL && rx->playback_buffer!=NULL) {
     rx->playback_buffer[rx->playback_offset++]=right_sample;

--- a/audio.c
+++ b/audio.c
@@ -41,6 +41,7 @@
 #include "radio.h"
 #include "receiver.h"
 #include "audio.h"
+#include "mode.h"
 
 int audio = 0;
 int audio_buffer_size = 256; // samples (both left and right)

--- a/configure.c
+++ b/configure.c
@@ -96,11 +96,13 @@ static   GtkWidget *function;
 
 #ifdef LOCALCW
 static GtkWidget *cwl_label;
-static GtkWidget *cwl_gpio_label;
 static GtkWidget *cwl;
 static GtkWidget *cwr_label;
-static GtkWidget *cwr_gpio_label;
 static GtkWidget *cwr;
+static GtkWidget *cws_label;
+static GtkWidget *cws;
+static GtkWidget *b_enable_cws;
+static GtkWidget *b_enable_cwlr;
 #endif
 
 static gboolean save_cb (GtkWidget *widget, GdkEventButton *event, gpointer data) {
@@ -149,8 +151,11 @@ static gboolean save_cb (GtkWidget *widget, GdkEventButton *event, gpointer data
     ENABLE_FUNCTION_BUTTON=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(b_enable_function))?1:0;
     FUNCTION_BUTTON=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(function));
 #ifdef LOCALCW
+    ENABLE_CW_BUTTONS=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(b_enable_cwlr))?1:0;
     CWL_BUTTON=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(cwl));
     CWR_BUTTON=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(cwr));
+    ENABLE_GPIO_SIDETONE=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(b_enable_cws))?1:0;
+    SIDETONE_GPIO=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(cws));
 #endif
 
     gpio_save_state();
@@ -331,6 +336,25 @@ void configure_gpio(GtkWidget *parent) {
   gtk_widget_show(S1);
   gtk_grid_attach(GTK_GRID(grid),S1,2,y,1,1);
 
+#ifdef LOCALCW
+  // With LOCALCW, the menu got too long (does not fit on the screen)
+  // Therefore it has been moved to the right of S1/S2/S3
+  // The GPIO side tone is also configured here. Note that
+  // these setting are only active when doing local CW
+  cwl_label=gtk_label_new("CWL GPIO:");
+  gtk_widget_show(cwl_label);
+  gtk_grid_attach(GTK_GRID(grid),cwl_label,3,y,1,1);
+
+  cwl=gtk_spin_button_new_with_range (0.0,100.0,1.0);
+  gtk_spin_button_set_value (GTK_SPIN_BUTTON(cwl),CWL_BUTTON);
+  gtk_widget_show(cwl);
+  gtk_grid_attach(GTK_GRID(grid),cwl,4,y,1,1);
+
+  b_enable_cwlr=gtk_check_button_new_with_label("Enable CW buttons");
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (b_enable_cwlr), ENABLE_CW_BUTTONS);
+  gtk_widget_show(b_enable_cwlr);
+  gtk_grid_attach(GTK_GRID(grid),b_enable_cwlr,5,y,1,1);
+#endif
 
   y++;
 
@@ -348,6 +372,17 @@ void configure_gpio(GtkWidget *parent) {
   gtk_widget_show(S2);
   gtk_grid_attach(GTK_GRID(grid),S2,2,y,1,1);
 
+#ifdef LOCALCW
+  cwr_label=gtk_label_new("CWR GPIO:");
+  gtk_widget_show(cwr_label);
+  gtk_grid_attach(GTK_GRID(grid),cwr_label,3,y,1,1);
+
+  cwr=gtk_spin_button_new_with_range (0.0,100.0,1.0);
+  gtk_spin_button_set_value (GTK_SPIN_BUTTON(cwr),CWR_BUTTON);
+  gtk_widget_show(cwr);
+  gtk_grid_attach(GTK_GRID(grid),cwr,4,y,1,1);
+#endif
+
   y++;
 
   b_enable_S3=gtk_check_button_new_with_label("Enable S3");
@@ -364,6 +399,21 @@ void configure_gpio(GtkWidget *parent) {
   gtk_widget_show(S3);
   gtk_grid_attach(GTK_GRID(grid),S3,2,y,1,1);
 
+#ifdef LOCALCW
+  cws_label=gtk_label_new("  SideTone GPIO:");
+  gtk_widget_show(cws_label);
+  gtk_grid_attach(GTK_GRID(grid),cws_label,3,y,1,1);
+
+  cws=gtk_spin_button_new_with_range (0.0,100.0,1.0);
+  gtk_spin_button_set_value (GTK_SPIN_BUTTON(cws),SIDETONE_GPIO);
+  gtk_widget_show(cws);
+  gtk_grid_attach(GTK_GRID(grid),cws,4,y,1,1);
+
+  b_enable_cws=gtk_check_button_new_with_label("Enable");
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (b_enable_cws), ENABLE_GPIO_SIDETONE);
+  gtk_widget_show(b_enable_cws);
+  gtk_grid_attach(GTK_GRID(grid),b_enable_cws,5,y,1,1);
+#endif
   y++;
 
   b_enable_S4=gtk_check_button_new_with_label("Enable S4");
@@ -430,38 +480,6 @@ void configure_gpio(GtkWidget *parent) {
 
   y++;
 
-#ifdef LOCALCW
-  cwl_label=gtk_label_new("CWL");
-  gtk_widget_show(cwl_label);
-  gtk_grid_attach(GTK_GRID(grid),cwl_label,0,y,1,1);
-
-  cwl_gpio_label=gtk_label_new("GPIO:");
-  gtk_widget_show(cwl_gpio_label);
-  gtk_grid_attach(GTK_GRID(grid),cwl_gpio_label,1,y,1,1);
-
-  cwl=gtk_spin_button_new_with_range (0.0,100.0,1.0);
-  gtk_spin_button_set_value (GTK_SPIN_BUTTON(cwl),CWL_BUTTON);
-  gtk_widget_show(cwl);
-  gtk_grid_attach(GTK_GRID(grid),cwl,2,y,1,1);
-
-  y++;
-
-  cwr_label=gtk_label_new("CWR");
-  gtk_widget_show(cwr_label);
-  gtk_grid_attach(GTK_GRID(grid),cwr_label,0,y,1,1);
-
-  cwr_gpio_label=gtk_label_new("GPIO:");
-  gtk_widget_show(cwr_gpio_label);
-  gtk_grid_attach(GTK_GRID(grid),cwr_gpio_label,1,y,1,1);
-
-  cwr=gtk_spin_button_new_with_range (0.0,100.0,1.0);
-  gtk_spin_button_set_value (GTK_SPIN_BUTTON(cwr),CWR_BUTTON);
-  gtk_widget_show(cwr);
-  gtk_grid_attach(GTK_GRID(grid),cwr,2,y,1,1);
-
-  y++;
-#endif
-  
   GtkWidget *save_b=gtk_button_new_with_label("Save");
   g_signal_connect (save_b, "button_press_event", G_CALLBACK(save_cb), NULL);
   gtk_grid_attach(GTK_GRID(grid),save_b,4,y-1,1,1);

--- a/configure.h
+++ b/configure.h
@@ -21,7 +21,7 @@
 #ifndef _CONFIGURE_H
 #define _CONFIGURE_H
 
-#ifdef INCLUDE_GPIO
+#ifdef GPIO
 void configure_gpio(GtkWidget *parent);
 #endif
 

--- a/discovery.c
+++ b/discovery.c
@@ -227,7 +227,7 @@ fprintf(stderr,"%p Protocol=%d name=%s\n",d,d->protocol,d->name);
             sprintf(text,"%s (%s) on USB /dev/ozy", d->name, d->protocol==ORIGINAL_PROTOCOL?"Protocol 1":"Protocol 2");
           } else {
 #endif
-            sprintf(text,"%s (%s %s) %s (%02X:%02X:%02X:%02X:%02X:%02X) on %s ",
+            sprintf(text,"%s (%s %s) %s (%02X:%02X:%02X:%02X:%02X:%02X) on %s",
                           d->name,
                           d->protocol==ORIGINAL_PROTOCOL?"Protocol 1":"Protocol 2",
                           version,

--- a/discovery.c
+++ b/discovery.c
@@ -60,7 +60,8 @@ fprintf(stderr,"start_cb: %p\n",data);
   // we otherwise lose the information about which app has been selected.
   if (radio->protocol == STEMLAB_PROTOCOL) {
     const int device_id = radio - discovered;
-    stemlab_start_app(gtk_combo_box_get_active_id(GTK_COMBO_BOX(apps_combobox[device_id])));
+    int ret;
+    ret=stemlab_start_app(gtk_combo_box_get_active_id(GTK_COMBO_BOX(apps_combobox[device_id])));
 #ifdef NO_AVAHI
     // We only have started the app, but not queried e.g. the MAC address.
     // Therefore, we have to clean up and re-start the discovery process.
@@ -69,6 +70,8 @@ fprintf(stderr,"start_cb: %p\n",data);
     g_idle_add(ext_discovery,NULL);
     return TRUE;
 #endif
+    // At this point, if stemlab_start_app failed, we cannot recover
+    if (ret != 0) exit(-1);
   }
   stemlab_cleanup();
 #endif

--- a/discovery.c
+++ b/discovery.c
@@ -44,6 +44,7 @@
 #include "stemlab_discovery.h"
 #endif
 #include "ext.h"
+#include "configure.h"
 
 static GtkWidget *discovery_dialog;
 static DISCOVERED *d;

--- a/exit_menu.c
+++ b/exit_menu.c
@@ -27,6 +27,9 @@
 #include "radio.h"
 #include "new_protocol.h"
 #include "old_protocol.h"
+#ifdef GPIO
+#include "gpio.h"
+#endif
 
 static GtkWidget *parent_window=NULL;
 

--- a/ext.c
+++ b/ext.c
@@ -170,11 +170,6 @@ int ext_tx_set_ps(void *data) {
   tx_set_ps(transmitter,(uintptr_t)data);
   return 0;
 }
-
-int ext_ps_twotone(void *data) {
-  ps_twotone((uintptr_t)data);
-  return 0;
-}
 #endif
 
 int ext_vfo_step(void *data) {

--- a/filter_menu.c
+++ b/filter_menu.c
@@ -196,6 +196,13 @@ void filter_menu(GtkWidget *parent) {
       }
       break;
 
+#ifdef DIGI_MODES
+    case modeDIGU:
+    case modeDIGL:
+      gtk_button_set_label(GTK_BUTTON(close_b), "DIGU/DIGL have a fixed wide filter.");
+      break;
+#endif
+
     default:
       for(i=0;i<FILTERS-2;i++) {
         FILTER* band_filter=&band_filters[i];

--- a/filter_menu.c
+++ b/filter_menu.c
@@ -67,9 +67,6 @@ static gboolean filter_select_cb (GtkWidget *widget, gpointer        data) {
   set_button_text_color(last_filter,"black");
   last_filter=widget;
   set_button_text_color(last_filter,"orange");
-  // DL1YCF added return statement to make the compiler happy.
-  // however I am unsure about the correct return value.
-  // I would have coded this as a void function.
   return FALSE;
 }
 
@@ -195,13 +192,6 @@ void filter_menu(GtkWidget *parent) {
       gtk_grid_attach(GTK_GRID(grid),b,2,1,1,1);
       }
       break;
-
-#ifdef DIGI_MODES
-    case modeDIGU:
-    case modeDIGL:
-      gtk_button_set_label(GTK_BUTTON(close_b), "DIGU/DIGL have a fixed wide filter.");
-      break;
-#endif
 
     default:
       for(i=0;i<FILTERS-2;i++) {

--- a/gpio.c
+++ b/gpio.c
@@ -974,8 +974,12 @@ fprintf(stderr,"setup_encoder_pin: pin=%d updown=%d\n",pin,up_down);
 
 #ifdef LOCALCW
 
+// Note we cannot use debouncing, as after the first interrupt,
+// we might read the wrong level. So we forward all CW interrupts
+// to the keyer.
+
 static void setup_cw_pin(int pin, void(*pAlert)(void)) {
-fprintf(stderr,"setup_cw_pin: pin=%d \n",pin);
+   fprintf(stderr,"setup_cw_pin: pin=%d \n",pin);
    pinMode(pin,INPUT);
    pullUpDnControl(pin,PUD_UP);
    usleep(10000);
@@ -983,19 +987,19 @@ fprintf(stderr,"setup_cw_pin: pin=%d \n",pin);
 }
 
 static void cwAlert_left() {
-	int level=digitalRead(CWL_BUTTON);
-	//fprintf(stderr,"cwl button : level=%d \n",level);
-   if (cw_keyer_internal == 0 ){
-      keyer_event(CWL_BUTTON, cw_active_level == 0 ? level : (level==0));
-   }
+    int level;
+    if (cw_keyer_internal != 0) return; // as quickly as possible
+    level=digitalRead(CWL_BUTTON);
+    //fprintf(stderr,"cwl button : level=%d \n",level);
+    keyer_event(CWL_BUTTON, cw_active_level == 0 ? level : (level==0));
 }
 
 static void cwAlert_right() {
-	int level=digitalRead(CWR_BUTTON);
-	//fprintf(stderr,"cwr button : level=%d \n",level);
-   if (cw_keyer_internal == 0 ){
-      keyer_event(CWR_BUTTON, cw_active_level == 0 ? level : (level==0));
-   }
+    int level;
+    if (cw_keyer_internal != 0) return; // as quickly as possible
+    level=digitalRead(CWR_BUTTON);
+    //fprintf(stderr,"cwr button : level=%d \n",level);
+     keyer_event(CWR_BUTTON, cw_active_level == 0 ? level : (level==0));
 }
 
 #endif

--- a/gpio.c
+++ b/gpio.c
@@ -859,8 +859,6 @@ void gpio_restore_state() {
  value=getProperty("ENABLE_GPIO_SIDETONE");		
  if(value) ENABLE_GPIO_SIDETONE=atoi(value);		
 #endif
-
-
 }
 
 void gpio_save_state() {
@@ -991,7 +989,7 @@ fprintf(stderr,"setup_encoder_pin: pin=%d updown=%d\n",pin,up_down);
 // Note we cannot use debouncing, as after the first interrupt,
 // we might read the wrong level. So we process all interrupts
 // to the keyer.
-// The only way to do proper debouncing is to record the times
+// The only way to do proper debouncing is to record the wall-clock time
 // of the last state change of each of the two buttons, and
 // disable further state changes for a short time (5 msec)
 

--- a/gpio.c
+++ b/gpio.c
@@ -859,6 +859,8 @@ void gpio_restore_state() {
  value=getProperty("ENABLE_GPIO_SIDETONE");		
  if(value) ENABLE_GPIO_SIDETONE=atoi(value);		
 #endif
+
+
 }
 
 void gpio_save_state() {

--- a/gpio.h
+++ b/gpio.h
@@ -80,8 +80,14 @@ extern int ENABLE_MOX_BUTTON;
 extern int MOX_BUTTON;
 extern int ENABLE_FUNCTION_BUTTON;
 extern int FUNCTION_BUTTON;
+#ifdef LOCALCW
 extern int CWL_BUTTON;
 extern int CWR_BUTTON;
+extern int SIDETONE_GPIO;
+extern int ENABLE_GPIO_SIDETONE;
+extern int ENABLE_CW_BUTTONS;
+void gpio_sidetone(int freq);
+#endif
 
 void gpio_restore_state();
 void gpio_save_state();

--- a/iambic.c
+++ b/iambic.c
@@ -78,6 +78,7 @@
 #include "new_protocol.h"
 #include "iambic.h"
 #include "transmitter.h"
+#include "ext.h"
 
 static void* keyer_thread(void *arg);
 static pthread_t keyer_thread_id;
@@ -122,6 +123,8 @@ static sem_t *cw_event;
 static sem_t cw_event;
 #endif
 
+static int cwvox = 0;
+
 int keyer_out = 0;
 
 // using clock_nanosleep of librt
@@ -158,14 +161,22 @@ void keyer_update() {
 void keyer_event(int gpio, int level) {
     int state = (level == 0);
 
-    // This is for aborting CAT CW messages if the key is hit.
     if (state) {
+        // This is for aborting CAT CW messages if the key is hit.
 	cw_key_hit = 1;
+        // we do PTT as soon as possible ...
+        if (running && !cwvox) {
+	   g_idle_add(ext_mox_update, (gpointer)(long) 1);
+           cwvox=(int) vox_hang;
+	}
     }
-    if (gpio == CWL_BUTTON)
+    if (gpio == CWL_BUTTON) {
         kcwl = state;
-    else  // CWR_BUTTON
+        //fprintf(stderr,"L=%d\n",state);   
+    } else { // CWR_BUTTON
         kcwr = state;
+        //fprintf(stderr,"R=%d\n",state);   
+    }
 
     if (state || cw_keyer_mode == KEYER_STRAIGHT) {
 #ifdef __APPLE__
@@ -189,7 +200,7 @@ void set_keyer_out(int state) {
 	//         MOX before starting local CW.
         keyer_out = state;
         if(protocol==NEW_PROTOCOL) schedule_high_priority(9);
-		fprintf(stderr,"set_keyer_out keyer_out= %d\n", keyer_out);
+		//fprintf(stderr,"set_keyer_out keyer_out= %d\n", keyer_out);
         if (state) {
 	    // DL1YCF: we must call cw_hold_key in *any* case, else no
 	    //         CW signal will be produced. We certainly do not
@@ -222,9 +233,21 @@ fprintf(stderr,"keyer_thread  state running= %d\n", running);
 
         key_state = CHECK;
 
-        while (key_state != EXITLOOP) {
-            switch(key_state) {
+	// If MOX still hanging, continue spinnning/checking and decrement cwvox
+
+        while (key_state != EXITLOOP || cwvox > 0) {
+          if (cwvox > 0 && key_state != EXITLOOP && key_state != CHECK) cwvox=(int) vox_hang;
+	  switch (key_state) {
+	    case EXITLOOP:
+		if (cwvox >0) cwvox--;
+                if (cwvox == 0) {
+		    g_idle_add(ext_mox_update,(gpointer)(long) 0);
+		} else {
+		    key_state=CHECK;
+		}
+	        break;
             case CHECK: // check for key press
+		if (cwvox > 1) cwvox--;
                 if (cw_keyer_mode == KEYER_STRAIGHT) {       // Straight/External key or bug
                     if (*kdash) {                  // send manual dashes
                         set_keyer_out(1);

--- a/iambic.c
+++ b/iambic.c
@@ -167,13 +167,11 @@ void keyer_event(int gpio, int level) {
            cwvox=(int) vox_hang;
 	}
     }
-    if (gpio == CWL_BUTTON) {
+    if (gpio == CWL_BUTTON)
         kcwl = state;
         //fprintf(stderr,"L=%d\n",state);   
-    } else { // CWR_BUTTON
+    else // CWR_BUTTON
         kcwr = state;
-        //fprintf(stderr,"R=%d\n",state);   
-    }
 
     if (state || cw_keyer_mode == KEYER_STRAIGHT) {
 #ifdef __APPLE__

--- a/iambic.c
+++ b/iambic.c
@@ -120,7 +120,6 @@ static sem_t cw_event;
 #endif
 
 static int cwvox = 0;
-static int first_dot = 0;
 
 int keyer_out = 0;
 
@@ -166,7 +165,6 @@ void keyer_event(int gpio, int level) {
         if (running && !cwvox && !mox) {
 	   g_idle_add(ext_mox_update, (gpointer)(long) 1);
            cwvox=(int) vox_hang;
-	   first_dot=1;
 	}
     }
     if (gpio == CWL_BUTTON) {
@@ -266,18 +264,10 @@ fprintf(stderr,"keyer_thread  state running= %d\n", running);
             case PREDOT:                         // need to clear any pending dots or dashes
                 clear_memory();
                 key_state = SENDDOT;
-		if (first_dot) {		// make the first "dot" or "dash" after automatic
-		   kdelay = -15;		// PTT switching 15 msec longer
-		   first_dot = 0;
-		}
                 break;
             case PREDASH:
                 clear_memory();
                 key_state = SENDDASH;
-		if (first_dot) {		// make the first "dot" or "dash" after automatic
-		   kdelay = -15;		// PTT switching 15 msec longer
-		   first_dot = 0;
-		}
                 break;
 
             // dot paddle  pressed so set keyer_out high for time dependant on speed

--- a/iambic.c
+++ b/iambic.c
@@ -164,8 +164,9 @@ void keyer_event(int gpio, int level) {
     if (state) {
         // This is for aborting CAT CW messages if the key is hit.
 	cw_key_hit = 1;
-        // we do PTT as soon as possible ...
-        if (running && !cwvox) {
+        // we do PTT as soon as possible, but disable cwvox if
+	// PTT has been engaged manually
+        if (running && !cwvox && !mox) {
 	   g_idle_add(ext_mox_update, (gpointer)(long) 1);
            cwvox=(int) vox_hang;
 	}

--- a/iambic.h
+++ b/iambic.h
@@ -26,5 +26,6 @@ extern int *kdash;
 void keyer_event(int gpio, int level);
 void keyer_update();
 void keyer_close();
+int  keyer_init();
 
 #endif

--- a/main.c
+++ b/main.c
@@ -203,7 +203,6 @@ static void activate_pihpsdr(GtkApplication *app, gpointer data) {
 
 fprintf(stderr,"width=%d height=%d\n", display_width, display_height);
 
-  // DL1YCF: use define'd constants here
   if(display_width>MAX_DISPLAY_WIDTH || display_height>MAX_DISPLAY_HEIGHT) {
     display_width=MAX_DISPLAY_WIDTH;
     display_height=MAX_DISPLAY_HEIGHT;

--- a/mode_menu.c
+++ b/mode_menu.c
@@ -33,6 +33,9 @@
 #include "receiver.h"
 #include "vfo.h"
 #include "button_text.h"
+#ifdef DIGI_MODES
+#include "noise_menu.h"		// for noise-on/off in DIGU/L
+#endif
 
 static GtkWidget *parent_window=NULL;
 
@@ -63,10 +66,17 @@ static gboolean mode_select_cb (GtkWidget *widget, gpointer        data) {
   set_button_text_color(last_mode,"black");
   last_mode=widget;
   set_button_text_color(last_mode,"orange");
+#ifdef DIGI_MODES
+  switch (m) {
+    case modeDIGL:
+    case modeDIGU:
+      noise_off();        // diable noise reduction machine completely for DIGI modes
+      break;
+    default:
+      update_noise();     // set noise reduction to the values stored in the current RECEIVER
+  }
+#endif
   vfo_mode_changed(m);
-  // DL1YCF added return statement to make the compiler happy.
-  // however I am unsure about the correct return value.
-  // I would have coded this as a void function.
   return FALSE;
 }
 

--- a/mode_menu.c
+++ b/mode_menu.c
@@ -33,9 +33,6 @@
 #include "receiver.h"
 #include "vfo.h"
 #include "button_text.h"
-#ifdef DIGI_MODES
-#include "noise_menu.h"		// for noise-on/off in DIGU/L
-#endif
 
 static GtkWidget *parent_window=NULL;
 
@@ -66,16 +63,6 @@ static gboolean mode_select_cb (GtkWidget *widget, gpointer        data) {
   set_button_text_color(last_mode,"black");
   last_mode=widget;
   set_button_text_color(last_mode,"orange");
-#ifdef DIGI_MODES
-  switch (m) {
-    case modeDIGL:
-    case modeDIGU:
-      noise_off();        // diable noise reduction machine completely for DIGI modes
-      break;
-    default:
-      update_noise();     // set noise reduction to the values stored in the current RECEIVER
-  }
-#endif
   vfo_mode_changed(m);
   return FALSE;
 }

--- a/new_menu.c
+++ b/new_menu.c
@@ -60,6 +60,7 @@
 #include "vfo_menu.h"
 #include "fft_menu.h"
 #include "main.h"
+#include "button_text.h"
 
 
 static GtkWidget *menu_b=NULL;
@@ -371,6 +372,19 @@ static gboolean ps_cb (GtkWidget *widget, GdkEventButton *event, gpointer data) 
   start_ps();
   return TRUE;
 }
+#else
+static gboolean tt_cb (GtkWidget *widget, GdkEventButton *event, gpointer data) {
+  // even without PURESIGNAL, a two-tone generator is nice-to-have
+  // so whe "PS" button now is a "TT" (two-tone) button.
+  int state=transmitter->twotone?0:1;
+  tx_set_twotone(transmitter,state);
+  if(state) {
+    set_button_text_color(widget,"red");
+  } else {
+    set_button_text_color(widget,"black");
+  }
+  return TRUE;
+}
 #endif
 
 #ifdef GPIO
@@ -477,6 +491,15 @@ void new_menu()
       GtkWidget *ps_b=gtk_button_new_with_label("PS");
       g_signal_connect (ps_b, "button-press-event", G_CALLBACK(ps_cb), NULL);
       gtk_grid_attach(GTK_GRID(grid),ps_b,(i%5),i/5,1,1);
+      i++;
+#else
+      GtkWidget *tt_b=gtk_button_new_with_label("TT");
+      gtk_widget_show(tt_b);
+      gtk_grid_attach(GTK_GRID(grid),tt_b,(i%5),i/5,1,1);
+      g_signal_connect (tt_b, "pressed", G_CALLBACK(tt_cb), NULL);
+      if(transmitter->twotone) {
+        set_button_text_color(tt_b,"red");
+      }
       i++;
 #endif
 

--- a/new_menu.c
+++ b/new_menu.c
@@ -372,19 +372,6 @@ static gboolean ps_cb (GtkWidget *widget, GdkEventButton *event, gpointer data) 
   start_ps();
   return TRUE;
 }
-#else
-static gboolean tt_cb (GtkWidget *widget, GdkEventButton *event, gpointer data) {
-  // even without PURESIGNAL, a two-tone generator is nice-to-have
-  // so whe "PS" button now is a "TT" (two-tone) button.
-  int state=transmitter->twotone?0:1;
-  tx_set_twotone(transmitter,state);
-  if(state) {
-    set_button_text_color(widget,"red");
-  } else {
-    set_button_text_color(widget,"black");
-  }
-  return TRUE;
-}
 #endif
 
 #ifdef GPIO
@@ -491,15 +478,6 @@ void new_menu()
       GtkWidget *ps_b=gtk_button_new_with_label("PS");
       g_signal_connect (ps_b, "button-press-event", G_CALLBACK(ps_cb), NULL);
       gtk_grid_attach(GTK_GRID(grid),ps_b,(i%5),i/5,1,1);
-      i++;
-#else
-      GtkWidget *tt_b=gtk_button_new_with_label("TT");
-      gtk_widget_show(tt_b);
-      gtk_grid_attach(GTK_GRID(grid),tt_b,(i%5),i/5,1,1);
-      g_signal_connect (tt_b, "pressed", G_CALLBACK(tt_cb), NULL);
-      if(transmitter->twotone) {
-        set_button_text_color(tt_b,"red");
-      }
       i++;
 #endif
 

--- a/new_menu.c
+++ b/new_menu.c
@@ -60,7 +60,6 @@
 #include "vfo_menu.h"
 #include "fft_menu.h"
 #include "main.h"
-#include "button_text.h"
 
 
 static GtkWidget *menu_b=NULL;

--- a/new_protocol.c
+++ b/new_protocol.c
@@ -417,10 +417,6 @@ void new_protocol_init(int pixels) {
       rc=sem_init(&iq_sem_buffer[ddc], 0, 0);
 #endif
       iq_thread_id[ddc] = g_thread_new( "ps iq thread", ps_iq_thread, (gpointer)(long)PS_TX_FEEDBACK);
-      if( ! iq_thread_id ) {
-        fprintf(stderr,"g_thread_new failed for ps_iq_thread: rx=%d\n",PS_TX_FEEDBACK);
-        exit( -1 );
-      }
       fprintf(stderr, "iq_thread: id=%p\n",iq_thread_id);
     }
 #endif
@@ -1446,7 +1442,7 @@ static void process_ps_iq_data(RECEIVER *rx) {
   }
   rx->iq_sequence++;
 
-  timestamp=((long long)(buffer[4]&0xFF)<<56)+((long long)(buffer[5]&0xFF)<<48)+((long long)(buffer[6]&0xFF)<<40)+((long long)(buffer[7]&0xFF)<<32);
+  timestamp=((long long)(buffer[4]&0xFF)<<56)+((long long)(buffer[5]&0xFF)<<48)+((long long)(buffer[6]&0xFF)<<40)+((long long)(buffer[7]&0xFF)<<32)+
   ((long long)(buffer[8]&0xFF)<<24)+((long long)(buffer[9]&0xFF)<<16)+((long long)(buffer[10]&0xFF)<<8)+(long long)(buffer[11]&0xFF);
   bitspersample=((buffer[12]&0xFF)<<8)+(buffer[13]&0xFF);
   samplesperframe=((buffer[14]&0xFF)<<8)+(buffer[15]&0xFF);

--- a/noise_menu.c
+++ b/noise_menu.c
@@ -132,7 +132,6 @@ static void snb_cb(GtkWidget *widget, gpointer data) {
 void noise_menu(GtkWidget *parent) {
   GtkWidget *b;
   int i;
-  int mode=vfo[active_receiver->id].mode;
 
   parent_window=parent;
 

--- a/noise_menu.c
+++ b/noise_menu.c
@@ -59,20 +59,7 @@ static gboolean delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_d
   return FALSE;
 }
 
-#ifdef DIGI_MODES
-void noise_off() {
-  SetEXTANBRun(active_receiver->id,  0);
-  SetEXTNOBRun(active_receiver->id,  0);
-  SetRXAANRRun(active_receiver->id,  0);
-  SetRXAEMNRRun(active_receiver->id, 0);
-  SetRXAANFRun(active_receiver->id,  0);
-  SetRXASNBARun(active_receiver->id, 0);
-}
-
 void update_noise() {
-#else
-static void update_noise() {
-#endif
   SetEXTANBRun(active_receiver->id, active_receiver->nb);
   SetEXTNOBRun(active_receiver->id, active_receiver->nb2);
   SetRXAANRRun(active_receiver->id, active_receiver->nr);
@@ -85,46 +72,60 @@ static void update_noise() {
 static void nb_none_cb(GtkWidget *widget, gpointer data) {
   active_receiver->nb=0;
   active_receiver->nb2=0;
+  mode_settings[vfo[active_receiver->id].mode].nb=0;
+  mode_settings[vfo[active_receiver->id].mode].nb2=0;
   update_noise();
 }
 
 static void nb_cb(GtkWidget *widget, gpointer data) {
   active_receiver->nb=1;
   active_receiver->nb2=0;
+  mode_settings[vfo[active_receiver->id].mode].nb=1;
+  mode_settings[vfo[active_receiver->id].mode].nb2=0;
   update_noise();
 }
 
 static void nr_none_cb(GtkWidget *widget, gpointer data) {
   active_receiver->nr=0;
   active_receiver->nr2=0;
+  mode_settings[vfo[active_receiver->id].mode].nr=0;
+  mode_settings[vfo[active_receiver->id].mode].nr2=0;
   update_noise();
 }
 
 static void nr_cb(GtkWidget *widget, gpointer data) {
   active_receiver->nr=1;
   active_receiver->nr2=0;
+  mode_settings[vfo[active_receiver->id].mode].nr=1;
+  mode_settings[vfo[active_receiver->id].mode].nr2=0;
   update_noise();
 }
 
 static void nb2_cb(GtkWidget *widget, gpointer data) {
   active_receiver->nb=0;
   active_receiver->nb2=1;
+  mode_settings[vfo[active_receiver->id].mode].nb=0;
+  mode_settings[vfo[active_receiver->id].mode].nb2=1;
   update_noise();
 }
 
 static void nr2_cb(GtkWidget *widget, gpointer data) {
   active_receiver->nr=0;
-  active_receiver->nr2=2;
+  active_receiver->nr2=1;
+  mode_settings[vfo[active_receiver->id].mode].nr=0;
+  mode_settings[vfo[active_receiver->id].mode].nr2=1;
   update_noise();
 }
 
 static void anf_cb(GtkWidget *widget, gpointer data) {
   active_receiver->anf=gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget));
+  mode_settings[vfo[active_receiver->id].mode].anf=active_receiver->anf;
   update_noise();
 }
 
 static void snb_cb(GtkWidget *widget, gpointer data) {
   active_receiver->snb=gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget));
+  mode_settings[vfo[active_receiver->id].mode].snb=active_receiver->snb;
   update_noise();
 }
 
@@ -159,14 +160,6 @@ void noise_menu(GtkWidget *parent) {
   gtk_grid_set_column_spacing (GTK_GRID(grid),5);
   gtk_grid_set_row_spacing (GTK_GRID(grid),5);
 
-#ifdef DIGI_MODES
-  if (mode == modeDIGU || mode == modeDIGL) {
-  GtkWidget *close_b=gtk_button_new_with_label("DIGU/DIGL have no noise options.");
-  g_signal_connect (close_b, "pressed", G_CALLBACK(close_cb), NULL);
-  gtk_grid_attach(GTK_GRID(grid),close_b,0,0,1,1);
-  }
-  else {
-#endif
   GtkWidget *close_b=gtk_button_new_with_label("Close");
   g_signal_connect (close_b, "pressed", G_CALLBACK(close_cb), NULL);
   gtk_grid_attach(GTK_GRID(grid),close_b,0,0,1,1);
@@ -251,9 +244,6 @@ void noise_menu(GtkWidget *parent) {
   gtk_widget_show(b_nr2);
   gtk_grid_attach(GTK_GRID(grid),b_nr2,col,row,1,1);
   g_signal_connect(b_nr2,"pressed",G_CALLBACK(nr2_cb),NULL);
-#ifdef DIGI_MODES
-  }
-#endif
 
   gtk_container_add(GTK_CONTAINER(content),grid);
 

--- a/noise_menu.c
+++ b/noise_menu.c
@@ -59,7 +59,20 @@ static gboolean delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_d
   return FALSE;
 }
 
+#ifdef DIGI_MODES
+void noise_off() {
+  SetEXTANBRun(active_receiver->id,  0);
+  SetEXTNOBRun(active_receiver->id,  0);
+  SetRXAANRRun(active_receiver->id,  0);
+  SetRXAEMNRRun(active_receiver->id, 0);
+  SetRXAANFRun(active_receiver->id,  0);
+  SetRXASNBARun(active_receiver->id, 0);
+}
+
+void update_noise() {
+#else
 static void update_noise() {
+#endif
   SetEXTANBRun(active_receiver->id, active_receiver->nb);
   SetEXTNOBRun(active_receiver->id, active_receiver->nb2);
   SetRXAANRRun(active_receiver->id, active_receiver->nr);
@@ -118,6 +131,7 @@ static void snb_cb(GtkWidget *widget, gpointer data) {
 void noise_menu(GtkWidget *parent) {
   GtkWidget *b;
   int i;
+  int mode=vfo[active_receiver->id].mode;
 
   parent_window=parent;
 
@@ -145,6 +159,14 @@ void noise_menu(GtkWidget *parent) {
   gtk_grid_set_column_spacing (GTK_GRID(grid),5);
   gtk_grid_set_row_spacing (GTK_GRID(grid),5);
 
+#ifdef DIGI_MODES
+  if (mode == modeDIGU || mode == modeDIGL) {
+  GtkWidget *close_b=gtk_button_new_with_label("DIGU/DIGL have no noise options.");
+  g_signal_connect (close_b, "pressed", G_CALLBACK(close_cb), NULL);
+  gtk_grid_attach(GTK_GRID(grid),close_b,0,0,1,1);
+  }
+  else {
+#endif
   GtkWidget *close_b=gtk_button_new_with_label("Close");
   g_signal_connect (close_b, "pressed", G_CALLBACK(close_cb), NULL);
   gtk_grid_attach(GTK_GRID(grid),close_b,0,0,1,1);
@@ -229,6 +251,9 @@ void noise_menu(GtkWidget *parent) {
   gtk_widget_show(b_nr2);
   gtk_grid_attach(GTK_GRID(grid),b_nr2,col,row,1,1);
   g_signal_connect(b_nr2,"pressed",G_CALLBACK(nr2_cb),NULL);
+#ifdef DIGI_MODES
+  }
+#endif
 
   gtk_container_add(GTK_CONTAINER(content),grid);
 

--- a/noise_menu.h
+++ b/noise_menu.h
@@ -19,7 +19,4 @@
 
 extern void noise_menu(GtkWidget *parent);
 
-#ifdef DIGI_MODES
-extern void noise_off();
 extern void update_noise();
-#endif

--- a/noise_menu.h
+++ b/noise_menu.h
@@ -18,3 +18,8 @@
 */
 
 extern void noise_menu(GtkWidget *parent);
+
+#ifdef DIGI_MODES
+extern void noise_off();
+extern void update_noise();
+#endif

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -132,7 +132,9 @@ static int running;
 static long ep4_sequence;
 
 // DL1YCF added this variable for lost-package-check
-static long last_seq_num=0;
+// init with -1 such that there is no error message if the
+// first packet is received with seq_num = 0
+static long last_seq_num=-1;
 
 static int current_rx=0;
 
@@ -843,8 +845,7 @@ void ozy_send_buffer() {
     }
 
 // TODO - add Alex Antenna
-    output_buffer[C3]=0x00;
-    output_buffer[C3] = receiver[0]->alex_attenuation;
+    output_buffer[C3] = (receiver[0]->alex_attenuation) & 0x03;  // do not set higher bits
     if(active_receiver->random) {
       output_buffer[C3]|=LT2208_RANDOM_ON;
     }

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -1178,7 +1178,7 @@ void ozy_send_buffer() {
         if(mode!=modeCWU && mode!=modeCWL) {
           // output_buffer[C1]|=0x00;
         } else {
-          if((tune==1) || (vox==1) || (cw_keyer_internal==0)) {
+          if((tune==1) || (vox==1) || (cw_keyer_internal==0) || (transmitter->twotone==1)) {
             output_buffer[C1]|=0x00;
           } else {
             output_buffer[C1]|=0x01;
@@ -1238,14 +1238,14 @@ void ozy_send_buffer() {
 //    If CW is done on the HPSDR board, we should not set
 //    the MOX bit, everything is done in the FPGA.
 //
-//    However, if we are doing CAT CW, local CW or tuning,
-//    we must put the SDR into TX mode.
+//    However, if we are doing CAT CW, local CW or tuning/TwoTone,
+//    we must put the SDR into TX mode *here*.
 //
-      if(tune || CAT_cw_is_active || !cw_keyer_internal) {
+      if(tune || CAT_cw_is_active || !cw_keyer_internal || transmitter->twotone) {
         output_buffer[C0]|=0x01;
       }
     } else {
-      // not doing CW? set MOX in any case.
+      // not doing CW? always set MOX if transmitting
       output_buffer[C0]|=0x01;
     }
   }

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -614,7 +614,7 @@ static void process_ozy_input_buffer(unsigned char  *buffer) {
               }
               break;
             case 3:
-              if(device==DEVICE_METIS)  {
+              if(device==DEVICE_HERMES)  {
                 left_sample_double_tx=left_sample_double;
                 right_sample_double_tx=right_sample_double;
                 add_ps_iq_samples(transmitter, left_sample_double_tx,right_sample_double_tx,left_sample_double_rx,right_sample_double_rx);

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -131,9 +131,6 @@ static double phase=0.0;
 static int running;
 static long ep4_sequence;
 
-// DL1YCF added this variable for lost-package-check
-// init with -1 such that there is no error message if the
-// first packet is received with seq_num = 0
 static long last_seq_num=-1;
 
 static int current_rx=0;

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -1043,9 +1043,8 @@ void ozy_send_buffer() {
         int power=0;
 #ifdef STEMLAB_FIX
 	//
-	// DL1YCF:
-	// On my HAMlab RedPitaya-based SDR transceiver, CW is generated on-board the RP.
-	// However, while in CW mode, DriveLevel changes do not become effective.
+	// Some HPSDR apps for the RedPitaya generate CW inside the FPGA, but while
+	// doing this, DriveLevel changes are processed by the server, but do not become effective.
 	// If the CW paddle is hit, the new PTT state is sent to piHPSDR, then the TX drive
 	// is sent the next time "command 3" is performed, but this often is too late and
 	// CW is generated with zero DriveLevel.
@@ -1369,13 +1368,11 @@ static void metis_restart() {
   current_rx=0;
 
 #ifdef STEMLAB_FIX
-  // DL1YCF:
-  // My RedPitaya HPSDR "clone" won't start up
-  // if too many commands are sent here. Note these
-  // packets are only there for sync-ing in the clock
-  // source etc.
-  // Note that always two 512-byte OZY buffers are
-  // combined into one METIS packet.
+  // 
+  // Some (older) HPSDR apps on the RedPitaya have very small
+  // buffers that over-run if too much data is sent
+  // to the RedPitaya *before* sending a METIS start packet.
+  // Therefore we send only four OZY buffers here.
   //
   command=1;   // ship out a "C0=0" and a "set tx" command
   ozy_send_buffer();

--- a/portaudio.c
+++ b/portaudio.c
@@ -47,23 +47,6 @@ static int mic_buffer_size;
 static int audio_buffer_size=256;
 
 //
-// compile with DummyTwoTone defined, and you will have an
-// additional "microphone" device producing a two-tone signal
-// with 700 and 1900 Hz.
-//
-#ifdef DummyTwoTone
-//
-// Dummy Two-tone input device
-//
-static int TwoTone=0;
-#define lentab 480
-static float sintab[lentab];
-static int tonept;
-#define factab 0.013089969389957471826927680763665  // 2 Pi / 480
-#endif
-
-
-//
 // AUDIO_GET_CARDS
 //
 // This inits PortAudio and looks for suitable input and output channels
@@ -75,11 +58,6 @@ void audio_get_cards()
   PaStreamParameters inputParameters, outputParameters;
 
   PaError err;
-
-#ifdef DummyTwoTone
-  // generate sine tab, 700 and 1900 Hz.
-  for (i=0; i< lentab; i++) sintab[i] = 0.45*(sin(7*i*factab)+sin(19*i*factab));
-#endif
 
   err = Pa_Initialize();
   if( err != paNoError )
@@ -103,14 +81,6 @@ void audio_get_cards()
         inputParameters.suggestedLatency = 0; /* ignored by Pa_IsFormatSupported() */
         inputParameters.hostApiSpecificStreamInfo = NULL;
         if (Pa_IsFormatSupported(&inputParameters, NULL, 48000.0) == paFormatIsSupported) {
-#ifdef DummyTwoTone
-          // duplicate the first suitable device, this will become
-          // a dummy two-tone generator
-          if (n_input_devices == 0) {
-            input_devices[n_input_devices]="TwoTone";
-            in_device_no[n_input_devices++] =i;
-          }
-#endif
           if (n_input_devices < MAXDEVICES) {
             input_devices[n_input_devices]=deviceInfo->name;
             in_device_no[n_input_devices++] =i;
@@ -193,13 +163,6 @@ int audio_open_input()
   }
   mic_buffer=(unsigned char *)malloc(2*framesPerBuffer);
   mic_buffer_size=framesPerBuffer;
-#ifdef DummyTwoTone
-  TwoTone=0;
-  if (transmitter->input_device == 0) {
-    tonept=0;
-    TwoTone=1;
-  }
-#endif
   return 0;
 }
 
@@ -218,9 +181,7 @@ int pa_mic_cb(const void *inputBuffer, void *outputBuffer, unsigned long framesP
 
 //
 // Convert input buffer in paFloat32 into a sequence of 16-bit
-// values in the mic buffer. If using the dummy Two-Tone
-// device, mic input will be discarded and a two-tone
-// signal produced instead.
+// values in the mic buffer.
 //
   if (mic_buffer == NULL) return paAbort;
 
@@ -230,25 +191,12 @@ int pa_mic_cb(const void *inputBuffer, void *outputBuffer, unsigned long framesP
       *p++ = 0;
       *p++ = 0;
     }
-#ifdef DummyTwoTone
-  } else if (TwoTone == 0) {
-#else
   } else {
-#endif
     for (i=0; i<framesPerBuffer; i++) {
       isample=(short) (in[i]*32768.0);
       *p++   = (isample & 0xFF);         // LittleEndian
       *p++   = (isample >> 8)& 0xFF;
     }
-#ifdef DummyTwoTone
-  } else {
-    for (i=0; i<framesPerBuffer; i++) {
-      isample=(short) (sintab[tonept++]*32767.0);
-      if (tonept == lentab) tonept=0;
-      *p++   = (isample & 0xFF);      // LittleEndian
-      *p++ = (isample >> 8)& 0xFF;
-    }
-#endif
   }
 //
 // Call routine to send mic buffer

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -322,7 +322,7 @@ void ps_twotone(int state) {
     //set_button_text_color(widget,"black");
   }
   if(state && transmitter->puresignal) {
-    info_thread_id=g_thread_new( "PS info", info_thread, NULL);
+    //info_thread_id=g_thread_new( "PS info", info_thread, NULL);
   } else {
     running=0;
   }

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -291,7 +291,6 @@ static void twotone_cb(GtkWidget *widget, gpointer data) {
     g_timeout_add((guint) 100, info_thread, NULL);
   } else {
     running=0;
-    usleep(20000); // to be sure info_thread stopped
   }
 }
 

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -278,6 +278,7 @@ fprintf(stderr,"ps_menu: entry %d is NULL\n", i);
     usleep(10000); // 10 ms
   }
   gtk_entry_set_text(GTK_ENTRY(entry[15]),"");
+  return NULL;
 }
 
 static void enable_cb(GtkWidget *widget, gpointer data) {

--- a/radio.c
+++ b/radio.c
@@ -1294,6 +1294,7 @@ fprintf(stderr,"radioRestoreState: %s\n",property_path);
     bandRestoreState();
     memRestoreState();
     vfo_restore_state();
+    modesettings_restore_state();
 #ifdef FREEDV
     freedv_restore_state();
 #endif
@@ -1493,6 +1494,7 @@ void radioSaveState() {
     setProperty("rx2_gain_slider",value);
 	
     vfo_save_state();
+    modesettings_save_state();
     sprintf(value,"%d",receivers);
     setProperty("receivers",value);
     for(i=0;i<receivers;i++) {

--- a/radio.c
+++ b/radio.c
@@ -66,6 +66,9 @@
 #include "toolbar.h"
 #include "rigctl.h"
 #include "ext.h"
+#ifdef LOCALCW
+#include "iambic.h"
+#endif
 
 #define min(x,y) (x<y?x:y)
 #define max(x,y) (x<y?y:x)

--- a/radio.c
+++ b/radio.c
@@ -833,7 +833,7 @@ void setTune(int state) {
       //schedule_general();
     }
     if(tune) {
-        for(i=0;i<receivers;i++) {
+      for(i=0;i<receivers;i++) {
         SetChannelState(receiver[i]->id,0,i==(receivers-1));
         set_displaying(receiver[i],0);
         if(protocol==NEW_PROTOCOL) {

--- a/radio.c
+++ b/radio.c
@@ -335,11 +335,7 @@ void reconfigure_radio() {
     }
   }
 
-#ifdef SPLIT_RXTX
-  reconfigure_transmitter(transmitter,rx_height/receivers);
-#else
   reconfigure_transmitter(transmitter,rx_height);
-#endif
 
 }
 
@@ -525,11 +521,7 @@ fprintf(stderr,"title: length=%d\n", (int)strlen(text));
   if(display_sliders) {
     rx_height-=SLIDERS_HEIGHT;
   }
-#ifdef SPLIT_RXTX
-  int tx_height=rx_height/receivers;
-#else
   int tx_height=rx_height;
-#endif
   rx_height=rx_height/receivers;
 
 
@@ -728,11 +720,7 @@ static void rxtx(int state) {
     tx_feedback->samples=0;
 #endif
 
-#ifdef SPLIT_RXTX
-    for(i=0;i<1;i++) {
-#else
     for(i=0;i<receivers;i++) {
-#endif
       SetChannelState(receiver[i]->id,0,i==(receivers-1));
       set_displaying(receiver[i],0);
       if(protocol==NEW_PROTOCOL) {
@@ -769,11 +757,7 @@ static void rxtx(int state) {
 //      gtk_widget_hide(audio_waterfall);
 //    }
 //#endif
-#ifdef SPLIT_RXTX
-    for(i=0;i<1;i++) {
-#else
     for(i=0;i<receivers;i++) {
-#endif
       gtk_fixed_put(GTK_FIXED(fixed),receiver[i]->panel,receiver[i]->x,receiver[i]->y);
       SetChannelState(receiver[i]->id,1,0);
       set_displaying(receiver[i],1);
@@ -849,11 +833,7 @@ void setTune(int state) {
       //schedule_general();
     }
     if(tune) {
-#ifdef SPLIT_RXTX
-        for(i=0;i<1;i++) {
-#else
         for(i=0;i<receivers;i++) {
-#endif
         SetChannelState(receiver[i]->id,0,i==(receivers-1));
         set_displaying(receiver[i],0);
         if(protocol==NEW_PROTOCOL) {

--- a/radio.c
+++ b/radio.c
@@ -563,7 +563,6 @@ fprintf(stderr,"Create %d receivers: height=%d\n",receivers,rx_height);
 
 #ifdef PURESIGNAL
   tx_set_ps_sample_rate(transmitter,protocol==NEW_PROTOCOL?192000:active_receiver->sample_rate);
-  // DL1YCF: we must create these receivers in ANY case to avoid seg-faults.
   receiver[PS_TX_FEEDBACK]=create_pure_signal_receiver(PS_TX_FEEDBACK, buffer_size,protocol==ORIGINAL_PROTOCOL?active_receiver->sample_rate:192000,display_width);
   receiver[PS_RX_FEEDBACK]=create_pure_signal_receiver(PS_RX_FEEDBACK, buffer_size,protocol==ORIGINAL_PROTOCOL?active_receiver->sample_rate:192000,display_width);
 #endif

--- a/receiver.c
+++ b/receiver.c
@@ -1096,21 +1096,17 @@ void receiver_frequency_changed(RECEIVER *rx) {
 
 void receiver_filter_changed(RECEIVER *rx) {
   int m=vfo[rx->id].mode;
-  switch (m) {
-    case modeFMN:
-      if(rx->deviation==2500) {
-        set_filter(rx,-4000,4000);
-      } else {
-        set_filter(rx,-8000,8000);
-      }
-      set_deviation(rx);
-      break;
-    default:
-	{
-    	FILTER *mode_filters=filters[m];
-    	FILTER *filter=&mode_filters[vfo[rx->id].filter];
-    	set_filter(rx,filter->low,filter->high);
-	}
+  if(m==modeFMN) {
+    if(rx->deviation==2500) {
+      set_filter(rx,-4000,4000);
+    } else {
+      set_filter(rx,-8000,8000);
+    }
+    set_deviation(rx);
+  } else {
+    FILTER *mode_filters=filters[m];
+    FILTER *filter=&mode_filters[vfo[rx->id].filter];
+    set_filter(rx,filter->low,filter->high);
   }
 }
 

--- a/receiver.c
+++ b/receiver.c
@@ -306,9 +306,15 @@ fprintf(stderr,"receiver_restore_state: id=%d\n",rx->id);
   sprintf(name,"receiver.%d.sample_rate",rx->id);
   value=getProperty(name);
   if(value) rx->sample_rate=atoi(value);
+#ifdef STEMLAB_FIX
+  // HPSDR apps on the RedPitay have hard-wired connections
+  // that should not be changed
+  fprintf(stderr,"STEMLAB: ignoring ADC settings for RX%d\n",rx->id);
+#else
   sprintf(name,"receiver.%d.adc",rx->id);
   value=getProperty(name);
   if(value) rx->adc=atoi(value);
+#endif
   sprintf(name,"receiver.%d.filter_low",rx->id);
   value=getProperty(name);
   if(value) rx->filter_low=atoi(value);
@@ -861,6 +867,12 @@ fprintf(stderr,"create_receiver: id=%d buffer_size=%d fft_size=%d pixels=%d fps=
           }
           break;
       }
+#ifdef STEMLAB_FIX
+//
+//    RedPitaya based HPSDR apps have hard-wired adc settings
+//
+      if (id == 1) rx->adc=1;
+#endif
   }
 fprintf(stderr,"create_receiver: id=%d default ddc=%d adc=%d\n",rx->id, rx->ddc, rx->adc);
   rx->sample_rate=48000;

--- a/receiver.c
+++ b/receiver.c
@@ -1105,14 +1105,6 @@ void receiver_filter_changed(RECEIVER *rx) {
       }
       set_deviation(rx);
       break;
-#ifdef DIGI_MODES
-    case modeDIGU:
-        set_filter(rx,0,3000);
-	break;
-    case modeDIGL:
-        set_filter(rx,-3000,0);
-        break;
-#endif
     default:
 	{
     	FILTER *mode_filters=filters[m];

--- a/receiver.c
+++ b/receiver.c
@@ -743,7 +743,7 @@ fprintf(stderr,"create_pure_signal_receiver: id=%d buffer_size=%d\n",id,buffer_s
   rx->sample_rate=sample_rate;
   rx->buffer_size=buffer_size;
   rx->fft_size=fft_size;
-  rx->pixels=0;
+  rx->pixels=pixels;   // need this for the "MON" button
   rx->fps=0;
 
   rx->width=0;

--- a/receiver.c
+++ b/receiver.c
@@ -1197,16 +1197,8 @@ static void process_rx_buffer(RECEIVER *rx) {
   short left_audio_sample;
   short right_audio_sample;
   int i;
-  int mute=0;
-  //
-  // DL1YCF: mute the receiver if we are transmitting on its frequency
-  //
-  if (isTransmitting()) {
-    if (!split && (rx->id == active_receiver->id)) mute=1;
-    if ( split && (rx->id != active_receiver->id)) mute=1;
-  }
   for(i=0;i<rx->output_samples;i++) {
-    if(mute) {
+    if(isTransmitting()) {
       left_audio_sample=0;
       right_audio_sample=0;
     } else {

--- a/sliders.c
+++ b/sliders.c
@@ -166,7 +166,12 @@ void set_attenuation_value(double value) {
 	  scale_status=ATTENUATION;
       scale_dialog=gtk_dialog_new_with_buttons(title,GTK_WINDOW(top_window),GTK_DIALOG_DESTROY_WITH_PARENT,NULL,NULL);
       GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(scale_dialog));
-      attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 31.0, 1.00);
+      if (filter_board == CHARLY25) {
+	// although this slider is hidden, its value range does matter
+        attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 36.0, 1.00);
+      } else {
+        attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 31.0, 1.00);
+      }
       gtk_widget_set_size_request (attenuation_scale, 400, 30);
       gtk_range_set_value (GTK_RANGE(attenuation_scale),(double)adc_attenuation[active_receiver->adc]);
       gtk_widget_show(attenuation_scale);
@@ -575,7 +580,11 @@ fprintf(stderr,"sliders_init: width=%d height=%d\n", width,height);
 	attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 60.0, 1.0);
 	gtk_range_set_value (GTK_RANGE(attenuation_scale),rx_gain_slider[active_receiver->adc]);
 #else
-	attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 31.0, 1.0);
+	if (filter_board == CHARLY25) {
+	  attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 36.0, 1.0);
+        } else {
+	  attenuation_scale=gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL,0.0, 31.0, 1.0);
+	}
 	gtk_range_set_value (GTK_RANGE(attenuation_scale),adc_attenuation[active_receiver->adc]);
 #endif
   

--- a/sliders.h
+++ b/sliders.h
@@ -20,6 +20,10 @@
 #ifndef _SLIDERS_H
 #define _SLIDERS_H
 
+// include these since we are using RECEIVER and TRANSMITTER
+#include "receiver.h"
+#include "transmitter.h"
+
 extern void att_type_changed(void);
 extern void update_att_preamp(void);
 
@@ -40,5 +44,6 @@ extern GtkWidget *sliders_init(int my_width, int my_height);
 extern void sliders_update();
 
 extern void set_squelch(RECEIVER* rx);
+extern void set_compression(TRANSMITTER *tx);
 
 #endif

--- a/stemlab_discovery.c
+++ b/stemlab_discovery.c
@@ -57,6 +57,8 @@ extern void status_text(const char *);
 
 #define ERROR_PREFIX "stemlab_discovery: "
 
+static size_t app_list_cb(void *buffer, size_t size, size_t nmemb, void *data);
+
 //
 // A bunch of callback-routines that use avahi, and are only needed by the
 // avahi-dependent version of stemlab_discovery(). These are only compiled
@@ -437,8 +439,8 @@ void stemlab_discovery() {
        p++;
      }
      if (len < 20) strcpy(inet,txt);
+     fclose(fpin);
    }
-   fclose(fpin);
    fprintf(stderr,"STEMLAB: using inet addr %s\n", inet);
    ip_address.sin_family = AF_INET;
    inet_aton(inet, &ip_address.sin_addr);

--- a/stemlab_discovery.h
+++ b/stemlab_discovery.h
@@ -18,5 +18,5 @@
 */
 
 extern void stemlab_discovery(void);
-extern void stemlab_start_app(const char * const app_id);
+extern int  stemlab_start_app(const char * const app_id);
 extern void stemlab_cleanup(void);

--- a/store_menu.c
+++ b/store_menu.c
@@ -83,9 +83,6 @@ static gboolean store_select_cb (GtkWidget *widget, gpointer data) {
 
    // Save in the file now..
    memSaveState();
-  // DL1YCF added return statement to make the compiler happy.
-  // however I am unsure about the correct return value.
-  // I would have coded this as a void function.
   return FALSE;
 }
 
@@ -111,9 +108,6 @@ static gboolean recall_select_cb (GtkWidget *widget, gpointer data) {
     vfo_mode_changed(mem[index].mode);
     g_idle_add(ext_vfo_update,NULL);
 
-  // DL1YCF added return statement to make the compiler happy.
-  // however I am unsure about the correct return value.
-  // I would have coded this as a void function.
   return FALSE;
 }
 

--- a/transmitter.c
+++ b/transmitter.c
@@ -1045,7 +1045,6 @@ void tx_set_ps(TRANSMITTER *tx,int state) {
 void tx_set_ps_sample_rate(TRANSMITTER *tx,int rate) {
   SetPSFeedbackRate (tx->id,rate);
 }
-#endif
 
 void tx_set_twotone(TRANSMITTER *tx,int state) {
   transmitter->twotone=state;
@@ -1070,6 +1069,10 @@ void tx_set_twotone(TRANSMITTER *tx,int state) {
   g_idle_add(ext_mox_update,(gpointer)(long)state);
 }
 
+void tx_set_ps_sample_rate(TRANSMITTER *tx,int rate) {
+  SetPSFeedbackRate (tx->id,rate);
+}
+#endif
 
 //
 // This is the old key-down/key-up interface for iambic.c

--- a/transmitter.c
+++ b/transmitter.c
@@ -986,10 +986,8 @@ void add_ps_iq_samples(TRANSMITTER *tx, double i_sample_tx,double q_sample_tx, d
   if(rx_feedback->samples>=rx_feedback->buffer_size) {
     if(isTransmitting()) {
       pscc(transmitter->id, rx_feedback->buffer_size, tx_feedback->iq_input_buffer, rx_feedback->iq_input_buffer);
-      if(transmitter->displaying) {
-        if(transmitter->feedback) {
-          Spectrum0(1, rx_feedback->id, 0, 0, rx_feedback->iq_input_buffer);
-        }
+      if(transmitter->displaying && transmitter->feedback) {
+        Spectrum0(1, rx_feedback->id, 0, 0, rx_feedback->iq_input_buffer);
       }
     }
     rx_feedback->samples=0;

--- a/transmitter.c
+++ b/transmitter.c
@@ -308,10 +308,13 @@ static gboolean update_display(gpointer data) {
     }
 #endif
 #ifdef PURESIGNAL
+    // if "MON" button is active (tx->feedback is TRUE),
+    // then obtain spectrum pixels from PS_RX_FEEDBACK,
+    // that is, display the (attenuated) TX signal from the "antenna"
     if(tx->puresignal && tx->feedback) {
-      RECEIVER *tx_feedback=receiver[PS_TX_FEEDBACK];
-      GetPixels(tx_feedback->id,0,tx_feedback->pixel_samples,&rc);
-      memcpy(tx->pixel_samples,tx_feedback->pixel_samples,sizeof(float)*tx->pixels);
+      RECEIVER *rx_feedback=receiver[PS_RX_FEEDBACK];
+      GetPixels(rx_feedback->id,0,rx_feedback->pixel_samples,&rc);
+      memcpy(tx->pixel_samples,rx_feedback->pixel_samples,sizeof(float)*tx->pixels);
     } else {
 #endif
       GetPixels(tx->id,0,tx->pixel_samples,&rc);
@@ -992,9 +995,7 @@ void add_ps_iq_samples(TRANSMITTER *tx, double i_sample_tx,double q_sample_tx, d
       pscc(transmitter->id, rx_feedback->buffer_size, tx_feedback->iq_input_buffer, rx_feedback->iq_input_buffer);
       if(transmitter->displaying) {
         if(transmitter->feedback) {
-          Spectrum0(1, tx_feedback->id, 0, 0, tx_feedback->iq_input_buffer);
-        //} else {
-        //  Spectrum0(1, rx_feedback->id, 0, 0, rx_feedback->iq_input_buffer);
+          Spectrum0(1, rx_feedback->id, 0, 0, rx_feedback->iq_input_buffer);
         }
       }
     }

--- a/transmitter.c
+++ b/transmitter.c
@@ -425,14 +425,7 @@ static gboolean update_display(gpointer data) {
       }
     } 
 
-#ifdef SPLIT_RXTX
-    // If the second RX is active, we rather want to see its S-meter instead of TX data
-    if (active_receiver == receiver[0]) {
-      meter_update(active_receiver,POWER,transmitter->fwd,transmitter->rev,transmitter->exciter,transmitter->alc);
-    }
-#else
     meter_update(active_receiver,POWER,transmitter->fwd,transmitter->rev,transmitter->exciter,transmitter->alc);
-#endif
 
     return TRUE; // keep going
   }

--- a/transmitter.c
+++ b/transmitter.c
@@ -758,7 +758,7 @@ static void full_tx_buffer(TRANSMITTER *tx) {
   // It is important query tx->mode and tune only once, to assure that
   // the two "if (cwmode)" queries give the same result.
 
-  cwmode = (tx->mode == modeCWL || tx->mode == modeCWU) && !tune;
+  cwmode = (tx->mode == modeCWL || tx->mode == modeCWU) && !tune && !tx->twotone;
 
   switch(protocol) {
     case ORIGINAL_PROTOCOL:
@@ -1057,7 +1057,16 @@ void tx_set_twotone(TRANSMITTER *tx,int state) {
   transmitter->twotone=state;
   if(state) {
     // DL1YCF: set frequencies and levels
-    SetTXAPostGenTTFreq(transmitter->id, 900.0, 1700.0);
+    switch(tx->mode) {
+      case modeCWL:
+      case modeLSB:
+      case modeDIGL:
+	SetTXAPostGenTTFreq(transmitter->id, -900.0, -1700.0);
+        break;
+      default:
+	SetTXAPostGenTTFreq(transmitter->id, 900.0, 1700.0);
+	break;
+    }
     SetTXAPostGenTTMag (transmitter->id, 0.49, 0.49);
     SetTXAPostGenMode(transmitter->id, 1);
     SetTXAPostGenRun(transmitter->id, 1);

--- a/transmitter.c
+++ b/transmitter.c
@@ -1042,10 +1042,6 @@ void tx_set_ps(TRANSMITTER *tx,int state) {
   vfo_update();
 }
 
-void tx_set_ps_sample_rate(TRANSMITTER *tx,int rate) {
-  SetPSFeedbackRate (tx->id,rate);
-}
-
 void tx_set_twotone(TRANSMITTER *tx,int state) {
   transmitter->twotone=state;
   if(state) {

--- a/transmitter.h
+++ b/transmitter.h
@@ -75,9 +75,10 @@ typedef struct _transmitter {
 
   int low_latency;
 
+// want to have a two-tone generator in any case
+  int twotone;
 #ifdef PURESIGNAL
   int puresignal;
-  int twotone;
   int feedback;
   int auto_on;
   int single_on;

--- a/transmitter.h
+++ b/transmitter.h
@@ -75,7 +75,6 @@ typedef struct _transmitter {
 
   int low_latency;
 
-// want to have a two-tone generator in any case
   int twotone;
 #ifdef PURESIGNAL
   int puresignal;

--- a/tx_panadapter.c
+++ b/tx_panadapter.c
@@ -49,9 +49,6 @@ static gfloat hz_per_pixel;
 static gfloat filter_left;
 static gfloat filter_right;
 
-#include "new_menu.h"
-#include "ext.h"
-#include "sliders.h"
 
 /* Create a new surface of the appropriate size to store our scribbles */
 static gboolean
@@ -143,16 +140,17 @@ tx_panadapter_motion_notify_event_cb (GtkWidget      *widget,
   int x, y;
   GdkModifierType state;
   gdk_window_get_device_position (event->window,
-                                  event->device,
-                                  &x,
-                                  &y,
-                                  &state);
+                                event->device,
+                                &x,
+                                &y,
+                                &state);
   if(((state & GDK_BUTTON1_MASK) == GDK_BUTTON1_MASK) || pressed) {
     int moved=last_x-x;
     vfo_move((long long)((float)moved*hz_per_pixel));
     last_x=x;
     has_moved=TRUE;
   }
+
   return TRUE;
 }
 

--- a/tx_panadapter.c
+++ b/tx_panadapter.c
@@ -204,6 +204,7 @@ void tx_panadapter_update(TRANSMITTER *tx) {
   int display_width=gtk_widget_get_allocated_width (tx->panadapter);
   int display_height=gtk_widget_get_allocated_height (tx->panadapter);
 
+  // id = VFO which contains the TX frequency
   int id = active_receiver->id;
   if (split) {
     id = 1-id;
@@ -284,7 +285,7 @@ void tx_panadapter_update(TRANSMITTER *tx) {
   // band edges
   long long min_display=frequency-half;
   long long max_display=frequency+half;
-  int b=vfo[i].band;
+  int b=vfo[id].band;
   BAND *band=band_get_band(b);
   if(band->frequencyMin!=0LL) {
     cairo_set_source_rgb (cr, 1.0, 0.0, 0.0);

--- a/vfo.c
+++ b/vfo.c
@@ -68,6 +68,7 @@ char *step_labels[]={"1Hz","10Hz","25Hz","50Hz","100Hz","250Hz","500Hz","1kHz","
 static GtkWidget* menu=NULL;
 static GtkWidget* band_menu=NULL;
 
+
 static void vfo_save_bandstack() {
   BANDSTACK *bandstack=bandstack_get_bandstack(vfo[0].band);
   BANDSTACK_ENTRY *entry=&bandstack->entry[vfo[0].bandstack];
@@ -345,15 +346,12 @@ void vfo_bandstack_changed(int b) {
 
 }
 
-//
-// When changing the mode, store the current filter setting
-// and for the new mode, switch to the filter we had the last time
-//
 void vfo_mode_changed(int m) {
   int id=active_receiver->id;
-
   vfo[id].mode=m;
-  // restore filter and NR configuration used last in the new mode
+//
+// Change to the filter/NR combination stored for this mode
+//
   vfo[id].filter      =mode_settings[m].filter;
   active_receiver->nr =mode_settings[m].nr;
   active_receiver->nr2=mode_settings[m].nr2;
@@ -697,7 +695,7 @@ void vfo_update() {
 	// If it is out-of-band, we display "Out of band" in red.
         // Frequencies we are not transmitting on are displayed in green
 	// (dimmed if the freq. does not belong to the active receiver).
-        // Depending on which receiver is the active one, and if we use slit,
+        // Depending on which receiver is the active one, and if we use split,
         // the following frequencies are used for transmitting (see old_protocol.c):
 	// id == 0, split == 0 : TX freq = VFO_A
 	// id == 0, split == 1 : TX freq = VFO_B

--- a/vfo.h
+++ b/vfo.h
@@ -20,6 +20,7 @@
 #ifndef _VFO_H
 #define _VFO_H
 
+#include "mode.h"
 
 enum {
   VFO_A=0,
@@ -44,6 +45,19 @@ struct _vfo {
 
 } vfo[MAX_VFOS];
 
+//
+// Store filter and NR settings on a per-mode basis
+//
+struct _mode_settings {
+  int filter;
+  int nb;
+  int nb2;
+  int nr;
+  int nr2;
+  int anf;
+  int snb;
+} mode_settings[MODES];
+
 
 extern int steps[];
 extern char *step_labels[];
@@ -57,6 +71,8 @@ extern void set_frequency();
 
 extern void vfo_save_state();
 extern void vfo_restore_state();
+extern void modesettings_save_state();
+extern void modesettings_restore_state();
 
 extern void vfo_band_changed(int b);
 extern void vfo_bandstack_changed(int b);

--- a/vfo_menu.c
+++ b/vfo_menu.c
@@ -193,7 +193,7 @@ static void enable_freedv_cb(GtkWidget *widget, gpointer data) {
 }
 #endif
 
-#ifdef FREEDV
+#ifdef PURESIGNAL
 static void enable_ps_cb(GtkWidget *widget, gpointer data) {
   tx_set_ps(transmitter,gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget)));
 }


### PR DESCRIPTION
MAJOR IMPROVEMENTS
==================

A. The STEMLAB_DISCOVERY option in the Makefiles now comes in
   two flavours, namely

   STEMLAB_DISCOVERY=STEMLAB_DISCOVERY

   or

   STEMLAB_DISCOVERY=STEMLAB_DISCOVERY_NOAVAHI

   (only the second version is present in Makefile.mac)

   The second version does not depend on avahi. Some users have reported
   difficulties to find the correct avahi development package
   for their RaspberryPi, so this option is useful there as well.
   
B. Changes to the filter and noise settings are now stored
   separately for each mode, and automatically activated
   when switching to that mode. For example, you can switch
   repeatedly back and forth between USB, DIGU and CWU and
   have 2.7 kHz/NR+ANF in USB, 3.3 kHz/no noise reduction
   in DIGU and 250 Hz/NR in CWU without going into the
   Mode or Filter menu in-between.
   Of course, the per-mode settings are saved to the
   props file and restored therefrom.

C. - Corrected LOCAL_CW, and implemented CW VOX. The hang time is
     that defined in the VOX menu.
   - GPIO side tone has moved from iambic.c (where it does not belong)
     to gpio.c (where it belongs).
   - All local CW GPIO options are now fully configurable throught the
     "gpio options" menu and saved/restored.

    LOCAL_CW corrections in collaboration with Johan, PA3GSB.

D. Made PURESIGNAL working (correcting several severe errors).
   The "info" thread in ps_menu was
   converted in to a glib_add_timeout event, because is obviously
   was not thread-safe (I had repeated and and seemingly indeterminate
   segfaults).
   The "MON" button in the PS menu had no function, I corrected this
   such that if MON is active, the TX window shows the RX feedback
   signal (that is, the signal you are sending to the antenna).

Error corrections (only the most important ones)
================================================

  - colouring the correct TX frequency in red in the VFO panel

    Note: throughout the code, the "algorithm" for determining
    ====  the VFO determining the TX frequency was varying.
          I tried to consistently switch to that one
          actually determining the TX freq which reads:

          TX_VFO = split ? (1-active_receiver->id) : active_receiver->id

          There was an "alternate algorithm" used in many places,
          which goes like

	  TX_VFO = split ? VFO_B : VFO_A

          In my view one can give preference to one or the other
          possiblility provided it is used throughout.
   
  - many corrections for CHARLY25 filter board, especially if it
    comes to using two receivers.

  - explicitly specifying levels and frequencies for two-tone
    (the defaults were silently used and make no sense for LSB).
