### PR TITLE
Corrected PURESIGNAL for METIS hardware (emergency fix)

### DIFF
--- a/old_protocol.c
+++ b/old_protocol.c
@@ -678,7 +678,7 @@ static void process_ozy_input_buffer(unsigned char  *buffer) {
               if(device==DEVICE_METIS)  {
                 left_sample_double_tx=left_sample_double;
                 right_sample_double_tx=right_sample_double;
-                add_ps_iq_samples(transmitter, left_sample_double_rx,right_sample_double_rx,left_sample_double_tx,right_sample_double_tx);
+                add_ps_iq_samples(transmitter, left_sample_double_tx,right_sample_double_tx,left_sample_double_rx,right_sample_double_rx);
               }
               break;
             case 2:


### PR DESCRIPTION
Although I have detected this with my "emulator" (I have no access to "real" METIS board hardware), I have very strong reasons to assume that this correction is badly needed. It seems to be an un-detected typo that was there from the beginning.
To be sure, I looked at other HPSDR software source code found there indeed, RX1 is the  attenuated feedback signal and RX2 the "outgoing" TX signal (in the same way Rx3/RX4 is used for this purpose with HERMES).

If there is someone using piHPSDR with PURESIGNAL and, say, an ANAN10, can you confirm this with REAL hardware?