### PR TITLE
P2 now working with PURESIGNAL, and further corrections

### DIFF
--- a/MacOS/Info.plist
+++ b/MacOS/Info.plist
@@ -12,5 +12,7 @@
 	<string>APPL</string>
         <key>CFBundleSignature</key>
 	<string>BNDL</string>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Allow for using Sound input devices</string>
 </dict>
 </plist>

--- a/MacOS/pihpsdr.sh
+++ b/MacOS/pihpsdr.sh
@@ -8,7 +8,15 @@
 # A full-fledged wrapper here would set dozens of
 # environment variables.
 #
-this=`dirname $0` 
-cd $this/../Resources
+#
+# Use $HOME/.pihpsdr as the working dir,
+# copy hpsdr.png to that location
 
+this=`dirname $0` 
+
+cd $HOME
+mkdir .pihpsdr
+cd .pihpsdr         # if this fails, stay in $HOME
+
+cp $this/../Resources/hpsdr.png .
 exec $this/pihpsdr-bin

--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,10 @@ release: $(PROGRAM)
 #############################################################################
 
 hpsdrsim.o:	hpsdrsim.c
-	$(CC) -c -O hpsdrsim.c
+	$(CC) -c -O -DALSASOUND hpsdrsim.c
 
-hpsdrsim:	hpsdrsim.o
-	$(LINK) -o hpsdrsim hpsdrsim.o $(AUDIO_LIBS) -lm -lpthread
+newhpsdrsim.o:	newhpsdrsim.c
+	$(CC) -c -O newhpsdrsim.c
+
+hpsdrsim:	hpsdrsim.o newhpsdrsim.o
+	$(LINK) -o hpsdrsim hpsdrsim.o newhpsdrsim.o -lasound -lm -lpthread

--- a/Makefile.mac
+++ b/Makefile.mac
@@ -456,11 +456,14 @@ release: $(PROGRAM)
 #
 #############################################################################
 
-hpsdrsim.o:     hpsdrsim.c
-	$(CC) -c -O $(PORTAUDIO_OPTIONS) hpsdrsim.c
+hpsdrsim.o:     hpsdrsim.c 
+	$(CC) -c -O -DPORTAUDIO hpsdrsim.c
         
-hpsdrsim:       hpsdrsim.o
-	$(LINK) -o hpsdrsim hpsdrsim.o $(AUDIO_LIBS) -lm -lpthread
+newhpsdrsim.o:	newhpsdrsim.c
+	$(CC) -c -O newhpsdrsim.c
+
+hpsdrsim:       hpsdrsim.o newhpsdrsim.o
+	$(LINK) -o hpsdrsim hpsdrsim.o newhpsdrsim.o -lportaudio -lm -lpthread
 
 #############################################################################
 #
@@ -507,17 +510,18 @@ app:	$(OBJS) $(REMOTE_OBJS) $(USBOZY_OBJS) $(LIMESDR_OBJS) $(FREEDV_OBJS) \
 	  libfn="`basename $$lib`"; \
 	  cp "$$lib" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
 	  chmod u+w "pihpsdr.app/Contents/Frameworks/$$libfn"; \
-	  install_name_tool -id "@executable_path/../Frameworks/$libfn" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
+	  install_name_tool -id "@executable_path/../Frameworks/$$libfn" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
 	  install_name_tool -change "$$lib" "@executable_path/../Frameworks/$$libfn" pihpsdr.app/Contents/MacOS/pihpsdr-bin; \
 	done
-#
-# Make "app" and copy local files app bundle
-#
-localapp:	app
-	cp wdspWisdom00 pihpsdr.app/Contents/Resources
-	cp *.props      pihpsdr.app/Contents/Resources
-	cp midi.inp     pihpsdr.app/Contents/Resources
-	cp ip.addr      pihpsdr.app/Contents/Resources
-
+	@# once more to install libraries on which libs just copied depend (such as wdsp -> fftw)
+	@for file in pihpsdr.app/Contents/Frameworks/*.dylib; do \
+	  for lib in `otool -L pihpsdr.app/Contents/Frameworks/*.dylib | grep -v pihpsdr.app | grep -v "executable_path" | grep dylib | sed -e "s/ (.*//" | grep -Ev "/(usr/lib|System)" | grep -Ev /libg  | grep -Ev pango | grep -Ev cairo`; do \
+	    libfn="`basename $$lib`"; \
+	    cp "$$lib" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
+	    chmod u+w "pihpsdr.app/Contents/Frameworks/$$libfn"; \
+	    install_name_tool -id "@executable_path/../Frameworks/$$libfn" "pihpsdr.app/Contents/Frameworks/$$libfn"; \
+	    install_name_tool -change "$$lib" "@executable_path/../Frameworks/$$libfn" $$file; \
+	  done; \
+	done
 #############################################################################
 

--- a/README.MacApp
+++ b/README.MacApp
@@ -1,0 +1,29 @@
+Using a pre-compiled "app" on MacOS
+===================================
+
+If you get this file together with a pre-compiled
+MacOS click-able "app" file, you need to install
+support files for the GTK graphical user interface.
+
+This can be done by the following sequence of commands, that
+have to by typed in after opening a terminal window (the terminal
+application resides in the "Utilities" folder within the MacOS
+"Applications" folder):
+
+  xcode-select --install
+  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install > brew.install
+  chmod 700 brew.install
+  ./brew.install
+  brew install gtk+3
+
+You will be asked once for the Mac administrator password, if you are asked
+later for MacOS keychain access, you can click "Don't allow".
+
+After this, double-click the pihpsdr application symbol. A window should open
+with the text "Creating FFTW Wisdom file". Be patient, this takes about 15
+minutes and will be skipped upon later invocations of pihpsdr.
+
+Then the discovery process starts, and if everything is hooked up correctly,
+you "see" your SDR and can click the "Start" button.
+
+Christoph van W"ullen, DL1YCF.

--- a/README.MacOS
+++ b/README.MacOS
@@ -17,20 +17,13 @@ To make piHPSDR work on MacOS, I had to do two major things:
 a) Semaphores: MacOS does not have sem_t variables, only
    sem_t pointers that must not be dereferences. Therefore
    it has no working sem_init.
-   On MacOS one must use sem_open instead and use sem_t
+   On MacOS one must use sem_unlink+sem_open instead and use sem_t
    pointers instead of sem_t variable throughout. This is
    not recommended for LINUX, since named semaphores stay
-   alive even when the program terminates (on MacOS, all
-   semaphores are automatically destroyed). Therefore
+   alive even when the program terminates (hence the sem_unlink
+   before each sem_open) Therefore
    *every* declaration of sem_t variable and *every*
-   call to semaphore functions had to be modified. Everything
-   is coded as
-
-#ifdef __APPLE__
-  use sem_t pointers
-#else
-  usem_t variables
-#endif
+   call to semaphore functions had to be modified.
 
    NOTE this change also applies to WDSP.
 

--- a/README.MacOS
+++ b/README.MacOS
@@ -87,6 +87,20 @@ there, "make -f Makefile.mac install" will put libwdsp.dylib in /usr/local/lib.
 This is needed by piHPSDR. The pihpsdr Makefile.mac assumes that WDSP can
 be linked with simply through the "-lwdsp" linker option.
 
+The following shell scripts installs all these prerequisites. At the beginning
+you have to give the administrator password. If the MacOS keychain ask you for
+permission, just answer with "Don't allow".
+
+#!/bin/sh
+
+xcode-select --install
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install portaudio
+brew install fftw
+brew install gtk+3
+brew install pkg-config
+brew install git
+
 ===================
 COMPILE and INSTALL
 ===================

--- a/hpsdrsim.c
+++ b/hpsdrsim.c
@@ -545,7 +545,6 @@ int main(int argc, char *argv[])
 					last_q_sample=dqsample;
 					if (j == 62) bp+=8; // skip 8 SYNC/C&C bytes of second block
                                  }
-				 fprintf(stderr,"LEVEL=%f\n", sum*0.007936508);
 				 // wrap-around of ring buffer
                                  if (txptr >= RTXLEN) txptr=0;
 				}

--- a/hpsdrsim.c
+++ b/hpsdrsim.c
@@ -205,16 +205,30 @@ static double  last_q_sample=0.0;
 static int  txptr=0;
 static int  rxptr=0;
 
+//
+// Unfortunately, the code number of the gear
+// differes in old and new protocol
+//
 
-#define DEVICE_ATLAS      0
-#define DEVICE_HERMES     1
-#define DEVICE_HERMES2    2
-#define DEVICE_ANGELIA    3
-#define DEVICE_ORION      4
-#define DEVICE_ORION2     5
-#define DEVICE_HERMESLITE 6
-#define DEVICE_C25        100
-static int DEVICE=DEVICE_HERMES;
+#define DEVICE_ATLAS           0
+#define DEVICE_HERMES          1
+#define DEVICE_HERMES2         2
+#define DEVICE_ANGELIA         4
+#define DEVICE_ORION           5
+#define DEVICE_HERMES_LITE     6
+#define DEVICE_ORION2         10
+#define DEVICE_C25           100
+
+#define NEW_DEVICE_ATLAS       0
+#define NEW_DEVICE_HERMES      1
+#define NEW_DEVICE_HERMES2     2
+#define NEW_DEVICE_ANGELIA     3
+#define NEW_DEVICE_ORION       4
+#define NEW_DEVICE_ORION2      5
+#define NEW_DEVICE_HERMES_LITE 6
+
+static int OLDDEVICE=DEVICE_HERMES;
+static int NEWDEVICE=NEW_DEVICE_HERMES;
 
 int main(int argc, char *argv[])
 {
@@ -268,16 +282,16 @@ int main(int argc, char *argv[])
  */
 
         if (argc > 1) {
-	    if (!strncmp(argv[1],"-atlas"  ,      6))  DEVICE=DEVICE_ATLAS;
-	    if (!strncmp(argv[1],"-hermes" ,      7))  DEVICE=DEVICE_HERMES;
-	    if (!strncmp(argv[1],"-hermes2" ,     8))  DEVICE=DEVICE_HERMES2;
-	    if (!strncmp(argv[1],"-angelia" ,     8))  DEVICE=DEVICE_ANGELIA;
-	    if (!strncmp(argv[1],"-orion" ,       6))  DEVICE=DEVICE_ORION;
-	    if (!strncmp(argv[1],"-orion2" ,      7))  DEVICE=DEVICE_ORION2;
-	    if (!strncmp(argv[1],"-hermeslite" , 11))  DEVICE=DEVICE_ORION2;
-	    if (!strncmp(argv[1],"-c25"    ,      4))  DEVICE=DEVICE_C25;
+	    if (!strncmp(argv[1],"-atlas"  ,      6))  {OLDDEVICE=DEVICE_ATLAS;       NEWDEVICE=NEW_DEVICE_ATLAS;}
+	    if (!strncmp(argv[1],"-hermes" ,      7))  {OLDDEVICE=DEVICE_HERMES;      NEWDEVICE=NEW_DEVICE_HERMES;}
+	    if (!strncmp(argv[1],"-hermes2" ,     8))  {OLDDEVICE=DEVICE_HERMES2;     NEWDEVICE=NEW_DEVICE_HERMES2;}
+	    if (!strncmp(argv[1],"-angelia" ,     8))  {OLDDEVICE=DEVICE_ANGELIA;     NEWDEVICE=NEW_DEVICE_ANGELIA;}
+	    if (!strncmp(argv[1],"-orion" ,       6))  {OLDDEVICE=DEVICE_ORION;       NEWDEVICE=NEW_DEVICE_ORION;}
+	    if (!strncmp(argv[1],"-orion2" ,      7))  {OLDDEVICE=DEVICE_ORION2;      NEWDEVICE=NEW_DEVICE_ORION2;}
+	    if (!strncmp(argv[1],"-hermeslite" , 11))  {OLDDEVICE=DEVICE_HERMES_LITE; NEWDEVICE=NEW_DEVICE_HERMES_LITE;}
+	    if (!strncmp(argv[1],"-c25"    ,      4))  {OLDDEVICE=DEVICE_C25;         NEWDEVICE=NEW_DEVICE_HERMES;}
         }
-	switch (DEVICE) {
+	switch (OLDDEVICE) {
 	    case   DEVICE_ATLAS:   fprintf(stderr,"DEVICE is ATLASS\n");      break;
 	    case   DEVICE_HERMES:  fprintf(stderr,"DEVICE is HERMES\n");      break;
 	    case   DEVICE_HERMES2: fprintf(stderr,"DEVICE is HERMES (2)\n");  break;
@@ -286,7 +300,7 @@ int main(int argc, char *argv[])
 	    case   DEVICE_ORION2:  fprintf(stderr,"DEVICE is ORION-II\n");    break;
 	    case   DEVICE_C25:     fprintf(stderr,"DEVICE is STEMlab/C25\n"); break;
 	}
-	reply[10]=DEVICE;
+	reply[10]=OLDDEVICE;
 
 	if ((sock_udp = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
 	{
@@ -719,7 +733,7 @@ int main(int argc, char *argv[])
 				  buffer[ 8]=0xDD;
 				  buffer[ 9]=0xEE;
 				  buffer[10]=0xFF;
-				  buffer[11]=DEVICE;
+				  buffer[11]=NEWDEVICE;
 				  buffer[12]=38;
 				  buffer[13]=103;
 				  buffer[20]=2;
@@ -738,7 +752,7 @@ int main(int argc, char *argv[])
                                   buffer[ 8]=0xDD;
                                   buffer[ 9]=0xEE;
                                   buffer[10]=0xFF;
-                                  buffer[11]=DEVICE;
+                                  buffer[11]=NEWDEVICE;
                                   buffer[12]=38;
                                   buffer[13]=103;
                                   buffer[20]=2;
@@ -765,7 +779,7 @@ int main(int argc, char *argv[])
                                   buffer[ 9]=0xEE;
                                   buffer[10]=0xFF;
 				  buffer[11]=103;
-				  buffer[12]=DEVICE;
+				  buffer[12]=NEWDEVICE;
 				  buffer[13]=(checksum >> 8) & 0xFF;
 				  buffer[14]=(checksum     ) & 0xFF;
 				  sendto(sock_udp, buffer, 60, 0, (struct sockaddr *)&addr_from, sizeof(addr_from));
@@ -791,7 +805,7 @@ int main(int argc, char *argv[])
                                   buffer[ 8]=0xDD;
                                   buffer[ 9]=0xEE;
                                   buffer[10]=0xFF;
-                                  buffer[11]=DEVICE;
+                                  buffer[11]=NEWDEVICE;
                                   buffer[12]=38;
                                   buffer[13]=103;
                                   buffer[20]=2;
@@ -868,7 +882,7 @@ void process_ep2(uint8_t *frame)
           chk_data(((frame[4] >> 6) & 1), MicTS, "TimeStampMic");
           chk_data(((frame[4] >> 7) & 1), CommonMercuryFreq,"Common Mercury Freq");
 
-	  if (DEVICE == DEVICE_C25) {
+	  if (OLDDEVICE == DEVICE_C25) {
               // Charly25: has two 18-dB preamps that are switched with "preamp" and "dither"
               //           and two attenuators encoded in Alex-ATT
 	      //           Both only applies to RX1!
@@ -957,7 +971,7 @@ void process_ep2(uint8_t *frame)
    	   chk_data((frame[4] & 0x1F) >> 0, rx_att[0], "RX1 ATT");
    	   chk_data((frame[4] & 0x20) >> 5, rx1_attE, "RX1 ATT enable");
 
-	   if (DEVICE != DEVICE_C25) {
+	   if (OLDDEVICE != DEVICE_C25) {
 	     // Set RX amplification factors. No switchable preamps available normally.
              rxatt_dbl[0]=pow(10.0, -0.05*(10*AlexAtt+rx_att[0]));
              rxatt_dbl[1]=pow(10.0, -0.05*(rx_att[1]));
@@ -997,7 +1011,7 @@ void process_ep2(uint8_t *frame)
             chk_data((frame[2] & 0x30) >> 4, rx_adc[6], "RX7 ADC");
 	    chk_data((frame[3] & 0x1f), txatt, "TX ATT");
 	    txatt_dbl=pow(10.0, -0.05*(double) txatt);
-	    if (DEVICE == DEVICE_C25) {
+	    if (OLDDEVICE == DEVICE_C25) {
 		// RedPitaya: Hard-wired ADC settings.
 		rx_adc[0]=0;
 		rx_adc[1]=1;
@@ -1128,7 +1142,7 @@ void *handler_ep6(void *arg)
 		    memset(pointer, 0, 504);
 		    for (j=0; j<n; j++) {
 			// ADC1: noise + weak tone on RX, feedback sig. on TX (except STEMlab)
-		        if (ptt && (DEVICE != DEVICE_C25)) {
+		        if (ptt && (OLDDEVICE != DEVICE_C25)) {
 			  i1=isample[rxptr]*txdrv_dbl;
 			  q1=qsample[rxptr]*txdrv_dbl;
 			  fac=IM3a+IM3b*(i1*i1+q1*q1);
@@ -1141,7 +1155,7 @@ void *handler_ep6(void *arg)
 			  adc1qsample += T0800Qtab[pt0800] * 83.886070 *rxatt_dbl[0];
 			}
 			// ADC2: noise + stronger tone on RX, feedback sig. on TX (only STEMlab)
-			if (ptt && (DEVICE == DEVICE_C25)) {
+			if (ptt && (OLDDEVICE == DEVICE_C25)) {
 			  i1=isample[rxptr]*txdrv_dbl;
 			  q1=qsample[rxptr]*txdrv_dbl;
 			  fac=IM3a+IM3b*(i1*i1+q1*q1);
@@ -1176,17 +1190,17 @@ void *handler_ep6(void *arg)
 				myqsample=0;
 				break;
 			    }
-			    if (DEVICE == DEVICE_ATLAS && ptt && (k==1)) {
+			    if (OLDDEVICE == DEVICE_ATLAS && ptt && (k==1)) {
 				// METIS: TX DAC signal goes to RX2 when TXing
 				myisample=dacisample;
 				myqsample=dacqsample;
 			    }
-			    if ((DEVICE==DEVICE_HERMES || DEVICE==DEVICE_HERMES2 || DEVICE==DEVICE_C25) && ptt && (k==3)) {
+			    if ((OLDDEVICE==DEVICE_HERMES || OLDDEVICE==DEVICE_HERMES2 || OLDDEVICE==DEVICE_C25) && ptt && (k==3)) {
 				// HERMES: TX DAC signal goes to RX4 when TXing
 				myisample=dacisample;
 				myqsample=dacqsample;
 			    }
-			    if ((DEVICE==DEVICE_ANGELIA || DEVICE == DEVICE_ORION || DEVICE== DEVICE_ORION2) && ptt && (k==4)) {
+			    if ((OLDDEVICE==DEVICE_ANGELIA || OLDDEVICE == DEVICE_ORION || OLDDEVICE== DEVICE_ORION2) && ptt && (k==4)) {
 				// ANGELIA and beyond: TX DAC signal goes to RX5 when TXing
 				myisample=dacisample;
 				myqsample=dacqsample;

--- a/iambic.c
+++ b/iambic.c
@@ -702,7 +702,8 @@ int keyer_init() {
 
     running = 1;
 #ifdef __APPLE__
-    cw_event=sem_open("CW", O_CREAT, 0700, 0);
+    sem_unlink("CW");
+    cw_event=sem_open("CW", O_CREAT | O_EXCL), 0700, 0);
     rc = (cw_event == SEM_FAILED);
 #else
     rc = sem_init(&cw_event, 0, 0);

--- a/midi3.c
+++ b/midi3.c
@@ -299,9 +299,11 @@ void DoTheMidi(enum MIDIaction action, enum MIDItype type, int val) {
 	    g_idle_add(ext_vfo_update, NULL);
 	    break;
 	case PS:
+#ifdef PURESIGNAL
 	    // toggle PURESIGNAL
 	    new=!(transmitter->puresignal);
 	    g_idle_add(ext_tx_set_ps,(gpointer) (uintptr_t) new);
+#endif
 	    break;
 	case SPLIT:
 	    // toggle split mode

--- a/new_discovery.c
+++ b/new_discovery.c
@@ -171,7 +171,7 @@ void new_discover(struct ifaddrs* iface) {
 
     if(sendto(discovery_socket,buffer,60,0,(struct sockaddr*)&to_addr,sizeof(to_addr))<0) {
         perror("new_discover: sendto socket failed for discovery_socket\n");
-        exit(-1);
+        return;
     }
 
     // wait for receive thread to complete

--- a/new_protocol.h
+++ b/new_protocol.h
@@ -73,6 +73,7 @@ extern int send_general;
 extern void schedule_high_priority();
 extern void schedule_general();
 extern void schedule_receive_specific();
+extern void schedule_transmit_specific();
 
 extern void new_protocol_init(int pixels);
 extern void new_protocol_stop();

--- a/newhpsdrsim.c
+++ b/newhpsdrsim.c
@@ -999,7 +999,6 @@ void *tx_thread(void * data) {
         sum += (di*di+dq*dq);
      }
      txlevel=sum * txdrv_dbl * txdrv_dbl * 0.0041667;
-     fprintf(stderr,"LEV1=%f LEV2=%f\n", sum*0.0041667, txlevel);
   }
   return NULL;
 }

--- a/newhpsdrsim.c
+++ b/newhpsdrsim.c
@@ -1,0 +1,1247 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <string.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <math.h>
+
+extern struct sockaddr_in addr_new;
+extern void audio_write(int16_t r, int16_t l);
+
+#define NUMRECEIVERS 8
+
+#define LENNOISE 192000
+#define NOISEDIV (RAND_MAX / 96000)
+
+extern double noiseItab[LENNOISE];
+extern double noiseQtab[LENNOISE];
+
+#define IM3a  0.60
+#define IM3b  0.20
+
+#define RTXLEN 64512
+#define NEWRTXLEN 64320
+extern double  isample[RTXLEN];  // shared with newhpsdrsim
+extern double  qsample[RTXLEN];  // shared with newhpsdrsim
+static int txptr = 10000;
+
+/*
+ * These variables represent the state of the machine
+ */
+// data from general packet
+static int ddc_port = 0;
+static int duc_port = 0;
+static int hp_port = 0;
+static int shp_port = 0;
+static int audio_port = 0;
+static int duc0_port = 0;
+static int ddc0_port = 0;
+static int mic_port = 0;
+static int wide_port = 0;
+static int wide_enable = 0;
+static int wide_len = 0;
+static int wide_size = 0;
+static int wide_rate = 0;
+static int wide_ppf = 0;
+static int port_mm = 0;
+static int port_smm = 0;
+static int pwm_min = 0;
+static int pwm_max = 0;
+static int bits = 0;
+static int hwtim = 0;
+static int pa_enable = 0;
+static int alex0_enable = 0;
+static int alex1_enable = 0;
+static int mm_port = 0;
+static int smm_port = 0;
+static int iqform = 0;
+
+// data from rx specific packet
+static int adc=0;
+static int adcdither[8];
+static int adcrandom[8];
+static int ddcenable[NUMRECEIVERS];
+static int adcmap[NUMRECEIVERS];
+static int rxrate[NUMRECEIVERS];
+static int syncddc[NUMRECEIVERS];
+
+//data from tx specific packet
+static int dac=0;
+static int cwmode=0;
+static int sidelevel=0;
+static int sidefreq=0;
+static int speed=0;
+static int weight=0;
+static int hang=0;
+static int delay=0;
+static int txrate=0;
+static int ducbits=0;
+static int orion=0;
+static int gain=0;
+static int txatt=0;
+
+//stat from high-priority packet
+static int run=0;
+static int ptt[4];
+static int cwx=0;
+static int dot=0;
+static int dash=0;
+static unsigned long rxfreq[NUMRECEIVERS];
+static unsigned long txfreq=0;
+static int txdrive=0;
+static int w1400=0;  // Xvtr and Audio enable
+static int ocout=0;
+static int db9=0;
+static int mercury_atts=0;
+static int alex0[32];
+static int alex1[32];
+static int stepatt0=0;
+static int stepatt1=0;
+
+//
+// floating point representation of TX-Drive and ADC0-Attenuator
+//
+static double rxatt0_dbl=1.0;
+static double rxatt1_dbl=1.0;
+static double txatt_dbl=1.0;
+static double txdrv_dbl = 0.0;
+
+// End of state variables
+
+static pthread_t ddc_specific_thread_id;
+static pthread_t duc_specific_thread_id;
+static pthread_t rx_thread_id[NUMRECEIVERS];
+static pthread_t tx_thread_id;
+static pthread_t mic_thread_id;
+static pthread_t audio_thread_id;
+static pthread_t highprio_thread_id = 0;
+static pthread_t send_highprio_thread_id;
+
+void   *ddc_specific_thread(void*);
+void   *duc_specific_thread(void*);
+void   *highprio_thread(void*);
+void   *send_highprio_thread(void*);
+void   *rx_thread(void *);
+void   *tx_thread(void *);
+void   *mic_thread(void *);
+void   *audio_thread(void *);
+
+static double txlevel;
+
+int new_protocol_running() {
+  if (run) return 1; else return 0;
+}
+
+void new_protocol_general_packet(unsigned char *buffer) {
+  static unsigned long seqnum=0;
+  unsigned long seqold;
+  int rc;
+
+  seqold = seqnum;
+  seqnum = (buffer[0] >> 24) + (buffer[1] << 16) + (buffer[2] << 8) + buffer[3];
+  if (seqnum != 0 && seqnum != seqold+1 ) {
+    fprintf(stderr,"GP: SEQ ERROR, old=%lu new=%lu\n", seqold, seqnum);
+  }
+
+  rc=(buffer[5] << 8) + buffer[6];
+  if (rc == 0) rc=1025;
+  if (rc != ddc_port) {
+    ddc_port=rc;
+    fprintf(stderr,"GP: RX specific rcv        port is  %4d\n", rc);
+  }
+  rc=(buffer[7] << 8) + buffer[8];
+  if (rc == 0) rc=1026;
+  if (rc != duc_port) {
+    duc_port=rc;
+    fprintf(stderr,"GP: TX specific rcv        port is  %4d\n", rc);
+  }
+  rc=(buffer[9] << 8) + buffer[10];
+  if (rc == 0) rc=1027;
+  if (rc != hp_port) {
+    hp_port=rc;
+    fprintf(stderr,"GP: HighPrio Port rcv      port is  %4d\n", rc);
+  }
+  rc=(buffer[11] << 8) + buffer[12];
+  if (rc == 0) rc=1025;
+  if (rc != shp_port) {
+    shp_port=rc;
+    fprintf(stderr,"GP: HighPrio Port snd      port is  %4d\n", rc);
+  }
+  rc=(buffer[13] << 8) + buffer[14];
+  if (rc == 0) rc=1028;
+  if (rc != audio_port) {
+    audio_port=rc;
+    fprintf(stderr,"GP: Audio rcv              port is  %4d\n", rc);
+  }
+  rc=(buffer[15] << 8) + buffer[16];
+  if (rc == 0) rc=1029;
+  if (rc != duc0_port) {
+    duc0_port=rc;
+    fprintf(stderr,"GP: TX data rcv base       port is  %4d\n", rc);
+  }
+  rc=(buffer[17] << 8) + buffer[18];
+  if (rc == 0) rc=1035;
+  if (rc != ddc0_port) {
+    ddc0_port=rc;
+    fprintf(stderr,"GP: RX data snd base       port is  %4d\n", rc);
+  }
+  rc=(buffer[19] << 8) + buffer[20];
+  if (rc == 0) rc=1026;
+  if (rc != mic_port) {
+    mic_port=rc;
+    fprintf(stderr,"GP: Microphone data snd    port is  %4d\n", rc);
+  }
+  rc=(buffer[21] << 8) + buffer[22];
+  if (rc == 0) rc=1027;
+  if (rc != wide_port) {
+    wide_port=rc;
+    fprintf(stderr,"GP: Wideband data snd       port is  %4d\n", rc);
+  }
+  rc=buffer[23]; 
+  if (rc != wide_enable) {
+    wide_enable = rc;
+    fprintf(stderr,"GP: Wideband Enable Flag is %d\n", rc);
+  }
+  rc=(buffer[24] << 8) + buffer[25]; if (rc == 0) rc=512;
+  if (rc != wide_len) {
+    wide_len=rc;
+    fprintf(stderr,"GP: WideBand Length is %d\n", rc);
+  }
+  rc=buffer[26]; if (rc == 0) rc=16;
+  if (rc != wide_size) {
+    wide_size=rc;
+    fprintf(stderr,"GP: Wideband sample size is %d\n", rc);
+  }
+  rc=buffer[27];
+  if (rc != wide_rate) {
+    wide_rate=rc;
+    fprintf(stderr,"GP: Wideband sample rate is %d\n", rc);
+  }
+  rc=buffer[28];
+  if (rc != wide_ppf) {
+    wide_ppf = rc;
+    fprintf(stderr,"GP: Wideband PPF is %d\n", rc);
+  }
+  rc = (buffer[29] << 8) + buffer[30];
+  if (rc != port_mm) {
+    port_mm=rc;
+    fprintf(stderr,"MemMapped Registers rcv port is %d\n", rc);
+  }
+  rc = (buffer[31] << 8) + buffer[32];
+  if (rc != port_smm) {
+    port_smm=rc;
+    fprintf(stderr,"MemMapped Registers snd port is %d\n", rc);
+  }
+  rc = (buffer[33] << 8) + buffer[34];
+  if (rc != pwm_min) {
+    pwm_min=rc;
+    fprintf(stderr,"GP: PWM Min value is %d\n", rc);
+  }
+  rc = (buffer[35] << 8) + buffer[36];
+  if (rc != pwm_max) {
+    pwm_max=rc;
+    fprintf(stderr,"GP: PWM Max value is %d\n", rc);
+  }
+  rc=buffer[37];
+  if (rc != bits) {
+    bits=rc;
+    fprintf(stderr,"GP: ModeBits=x%02x\n", rc);
+  }
+  rc=buffer[38];
+  if (rc != hwtim) {
+    hwtim=rc;
+    fprintf(stderr,"GP: Hardware Watchdog enabled=%d\n", rc);
+  }
+
+  iqform = buffer[39];				if (iqform == 0) iqform=3;
+  if (iqform != 3) fprintf(stderr,"GP: Wrong IQ Format requested: %d\n",iqform);
+
+  rc = (buffer[58] & 0x01);
+  if (rc != pa_enable) {
+    pa_enable=rc;
+    fprintf(stderr,"GP: PA enabled=%d\n", rc);
+  }
+
+  rc=buffer[59] & 0x01;
+  if (rc != alex0_enable) {
+    alex0_enable=rc;
+    fprintf(stderr,"GP: ALEX0 register enable=%d\n", rc);
+  }
+  rc=(buffer[59] & 0x02) >> 1;
+  if (rc != alex1_enable) {
+    alex1_enable=rc;
+    fprintf(stderr,"GP: ALEX1 register enable=%d\n", rc);
+  }
+  //
+  // Start HighPrio thread if we arrive here for the first time
+  // The HighPrio thread keeps running all the time.
+  //
+  if (!highprio_thread_id) {
+	if (pthread_create(&highprio_thread_id, NULL, highprio_thread, NULL) < 0) {
+	  perror("***** ERROR: Create HighPrio thread");
+	}
+	pthread_detach(highprio_thread_id);
+
+  //
+  // init state arrays to zero for the first time
+  //
+  memset(adcdither, 0, 8*sizeof(int));
+  memset(adcrandom, 0, 8*sizeof(int));
+  memset(ddcenable, 0, NUMRECEIVERS*sizeof(int));
+  memset(adcmap, 0, NUMRECEIVERS*sizeof(int));
+  memset(syncddc, 0, NUMRECEIVERS*sizeof(int));
+
+  memset(rxfreq, 0, NUMRECEIVERS*sizeof(unsigned long));
+  memset(alex0, 0, 32*sizeof(int));
+  memset(alex1, 0, 32*sizeof(int));
+  memset(ptt  , 0, 4*sizeof(int));
+  }
+}
+
+void *ddc_specific_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  socklen_t lenaddr = sizeof(addr);
+  unsigned long seqnum,seqold;
+  struct timeval tv;
+  unsigned char buffer[2000];
+  int yes = 1;
+  int rc;
+  int i,j;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: RX specific: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+  tv.tv_sec = 0;
+  tv.tv_usec = 10000;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *)&tv, sizeof(tv));
+
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(ddc_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: RX specific: bind");
+    return NULL;
+  }
+
+  while(run) {
+     rc = recvfrom(sock, buffer, 1444, 0,(struct sockaddr *)&addr, &lenaddr);
+     if (rc < 0 && errno != EAGAIN) {
+       perror("***** ERROR: DDC specific thread: recvmsg");
+       break;
+     }
+     if (rc < 0) continue;
+     if (rc != 1444) {
+       fprintf(stderr,"RX: Received DDC specific packet with incorrect length");
+       break;
+     }
+     seqold = seqnum;
+     seqnum = (buffer[0] >> 24) + (buffer[1] << 16) + (buffer[2] << 8) + buffer[3];
+     if (seqnum != 0 &&seqnum != seqold+1 ) {
+       fprintf(stderr,"GP: SEQ ERROR, old=%lu new=%lu\n", seqold, seqnum);
+     }
+     if (adc != buffer[4]) {
+       adc=buffer[4];
+       fprintf(stderr,"RX: Number of ADCs: %d\n",adc);
+     }
+     for (i=0; i<8; i++) {
+       rc=(buffer[5] >> i) & 0x01;
+       if (rc != adcdither[i]) {
+         adcdither[i]=rc;
+	 fprintf(stderr,"RX: ADC%d dither=%d\n",i,rc);
+       }
+     }
+     for (i=0; i<8; i++) {
+       rc=(buffer[6] >> i) & 0x01;
+       if (rc != adcrandom[i]) {
+         adcrandom[i]=rc;
+	 fprintf(stderr,"RX: ADC%d random=%d\n",i,rc);
+       }
+     }
+
+     for (i=0; i<NUMRECEIVERS; i++) {
+       int modified=0;
+
+       rc=(buffer[7 + (i/8)] >> (i % 8)) & 0x01;
+       if (rc != ddcenable[i]) {
+	 modified=1;
+	 ddcenable[i]=rc;
+       }
+       
+       rc=buffer[17+6*i];
+       if (rc != adcmap[i]) {
+	 modified=1;
+	 adcmap[i]=rc;
+       }
+
+       rc=(buffer[18+6*i] << 8) + buffer[19+6*i];
+       if (rc != rxrate[i]) {
+	 modified=1;
+	 rxrate[i]=rc;
+         modified=1;
+       }
+
+       if (syncddc[i] != buffer[1363+i]) {
+	 syncddc[i]=buffer[1363+i];
+         modified=1;
+       }
+       rc=(buffer[7 + (i/8)] >> (i % 8)) & 0x01;
+       if (rc != ddcenable[i]) {
+	 modified=1;
+	 ddcenable[i]=rc;
+       }
+       if (modified) {
+	 fprintf(stderr,"RX: DDC%d Enable=%d ADC%d Rate=%d SyncMap=%02x\n",
+		i,ddcenable[i], adcmap[i], rxrate[i], syncddc[i]);
+       }
+     }
+  }
+  close(sock);
+  return NULL;
+}
+
+void *duc_specific_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  socklen_t lenaddr=sizeof(addr);
+  unsigned long seqnum,seqold;
+  struct timeval tv;
+  unsigned char buffer[100];
+  int yes = 1;
+  int rc;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: TX specific: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+  tv.tv_sec = 0;
+  tv.tv_usec = 10000;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *)&tv, sizeof(tv));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(duc_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: TX specific: bind");
+    return NULL;
+  }
+
+  while(run) {
+     rc = recvfrom(sock, buffer, 60, 0,(struct sockaddr *)&addr, &lenaddr);
+     if (rc < 0 && errno != EAGAIN) {
+       perror("***** ERROR: DUC specific thread: recvmsg");
+       break;
+     }
+     if (rc < 0) continue;
+     if (rc != 60) {
+	fprintf(stderr,"TX: DUC Specific: wrong length\n");
+        break;
+     }
+     seqold = seqnum;
+     seqnum = (buffer[0] >> 24) + (buffer[1] << 16) + (buffer[2] << 8) + buffer[3];
+     if (seqnum != 0 &&seqnum != seqold+1 ) {
+       fprintf(stderr,"GP: SEQ ERROR, old=%lu new=%lu\n", seqold, seqnum);
+     }
+     if (dac != buffer[4]) {
+	dac=buffer[4];
+	fprintf(stderr,"TX: Number of DACs: %d\n", dac);
+     }
+     if (cwmode != buffer[5]) {
+	cwmode=buffer[5];
+	fprintf(stderr,"TX: CW mode bits = %x\n",cwmode);
+     }
+     if (sidelevel != buffer[6]) {
+	sidelevel=buffer[6];
+	fprintf(stderr,"TX: CW side tone level: %d\n", sidelevel);
+     }
+     rc=(buffer[7] << 8) + buffer[8];
+     if (rc != sidefreq) {
+	sidefreq = rc;
+	fprintf(stderr,"TX: CW sidetone freq: %d\n", sidefreq);
+     }
+     if (speed != buffer[9]) {
+	speed = buffer[9];
+	fprintf(stderr,"TX: CW keyer speed: %d wpm\n", speed);
+     }
+     if (weight != buffer[10]) {
+	weight=buffer[10];
+	fprintf(stderr,"TX: CW weight: %d\n", weight);
+     }
+     rc=(buffer[11] << 8) + buffer[12];
+     if (hang != rc) {
+	hang = rc;
+	fprintf(stderr,"TX: CW hang time: %d msec\n", hang);
+     }
+     if (delay != buffer[13]) {
+	delay=buffer[13];
+	fprintf(stderr,"TX: RF delay: %d msec\n", delay);
+     }
+     rc=(buffer[14] << 8) + buffer[15];
+     if (txrate != rc) {
+	txrate = rc;
+	fprintf(stderr,"TX: DUC sample rate: %d\n", rc);
+     }
+     if (ducbits != buffer[16]) {
+	ducbits=buffer[16];
+	fprintf(stderr,"TX: DUC sample width: %d bits\n", ducbits);
+     }
+     if (orion != buffer[50]) {
+	orion=buffer[50];
+	fprintf(stderr,"TX: ORION bits (mic etc): %x\n", orion);
+     }
+     if (gain != buffer[51]) {
+	gain= buffer[51];
+	fprintf(stderr,"TX: LineIn Gain (dB): %f\n", 12.0 - 1.5*gain);
+     }
+     if (txatt != buffer[59]) {
+	txatt = buffer[59];
+	txatt_dbl=pow(10.0, -0.05*txatt);
+	fprintf(stderr,"TX: ATT DUC0/ADC0: %d\n", txatt);
+     }
+  }
+  close(sock);
+  return NULL;
+}
+
+void *highprio_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  socklen_t lenaddr=sizeof(addr);
+  unsigned long seqnum,seqold;
+  unsigned char buffer[2000];
+  struct timeval tv;
+  int yes = 1;
+  int rc;
+  unsigned long freq;
+  int i;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: HP: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+  tv.tv_sec = 0;
+  tv.tv_usec = 10000;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *)&tv, sizeof(tv));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(hp_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: HP: bind");
+    return NULL;
+  }
+
+  while(1) {
+     rc = recvfrom(sock, buffer, 1444, 0,(struct sockaddr *)&addr, &lenaddr);
+     if (rc < 0 && errno != EAGAIN) {
+       perror("***** ERROR: HighPrio thread: recvmsg");
+       break;
+     }
+     if (rc < 0) continue;
+     if (rc != 1444) {
+       fprintf(stderr,"Received HighPrio packet with incorrect length");
+       break;
+     }
+     seqold = seqnum;
+     seqnum = (buffer[0] >> 24) + (buffer[1] << 16) + (buffer[2] << 8) + buffer[3];
+     if (seqnum != 0 &&seqnum != seqold+1 ) {
+       fprintf(stderr,"GP: SEQ ERROR, old=%lu new=%lu\n", seqold, seqnum);
+     }
+     rc=(buffer[4] >> 0) & 0x01;
+     if (rc != run) {
+	run=rc;
+	fprintf(stderr,"HP: Run=%d\n", rc);
+        // if run=0, wait for threads to complete, otherwise spawn them off
+        if (run) {
+          if (pthread_create(&ddc_specific_thread_id, NULL, ddc_specific_thread, NULL) < 0) {
+            perror("***** ERROR: Create DDC specific thread");
+          }
+          if (pthread_create(&duc_specific_thread_id, NULL, duc_specific_thread, NULL) < 0) {
+            perror("***** ERROR: Create DUC specific thread");
+          }
+          for (i=0; i< NUMRECEIVERS; i++) {
+            if (pthread_create(&rx_thread_id[i], NULL, rx_thread, (void *) (uintptr_t) i) < 0) {
+              perror("***** ERROR: Create RX thread");
+            }
+	  }
+          if (pthread_create(&tx_thread_id, NULL, tx_thread, NULL) < 0) {
+            perror("***** ERROR: Create TX thread");
+          }
+          if (pthread_create(&send_highprio_thread_id, NULL, send_highprio_thread, NULL) < 0) {
+            perror("***** ERROR: Create SendHighPrio thread");
+          }
+          if (pthread_create(&mic_thread_id, NULL, mic_thread, NULL) < 0) {
+            perror("***** ERROR: Create Mic thread");
+          }
+          if (pthread_create(&audio_thread_id, NULL, audio_thread, NULL) < 0) {
+            perror("***** ERROR: Create Audio thread");
+          }
+        } else {
+          pthread_join(ddc_specific_thread_id, NULL);
+          pthread_join(duc_specific_thread_id, NULL);
+          for (i=0; i<NUMRECEIVERS; i++) {
+            pthread_join(rx_thread_id[i], NULL);
+          }
+          pthread_join(send_highprio_thread_id, NULL);
+          pthread_join(tx_thread_id, NULL);
+          pthread_join(mic_thread_id, NULL);
+          pthread_join(audio_thread_id, NULL);
+        }
+     }
+     for (i=0; i<4; i++) {
+       rc=(buffer[4] >> (i+1)) & 0x01;
+       if (rc != ptt[i]) {
+	ptt[i]=rc;
+	fprintf(stderr,"HP: PTT%d=%d\n", i, rc);
+      }
+     }
+     rc=(buffer[5] >> 0) & 0x01;
+     if (rc != cwx) {
+	cwx=rc;
+	fprintf(stderr,"HP: CWX=%d\n", rc);
+     }
+     rc=(buffer[5] >> 1) & 0x01;
+     if (rc != dot) {
+	dot=rc;
+	fprintf(stderr,"HP: DOT=%d\n", rc);
+     }
+     rc=(buffer[5] >> 2) & 0x01;
+     if (rc != dash) {
+	dash=rc;
+	fprintf(stderr,"HP: DASH=%d\n", rc);
+     }
+     for (i=0; i<NUMRECEIVERS; i++) {
+	freq=(buffer[ 9+4*i] << 24) + (buffer[10+4*i] << 16) + (buffer[11+4*i] << 8) + buffer[12+4*i];
+        if (bits & 0x08) {
+	  freq=round(122880000.0*(double) freq / 4294967296.0);
+	}
+        if (freq != rxfreq[i]) {
+	  rxfreq[i]=freq;
+	  fprintf(stderr,"HP: DDC%d freq: %lu\n", i, freq);
+	}
+     }
+     freq=(buffer[329] << 24) + (buffer[330] << 16) + (buffer[331] << 8) + buffer[332];
+     if (bits & 0x08) {
+	freq=round(122880000.0*(double) freq / 4294967296.0);
+     }
+     if (freq != txfreq) {
+	txfreq=freq;
+	fprintf(stderr,"HP: DUC freq: %lu\n", freq);
+     }
+     rc=buffer[345];
+     if (rc != txdrive) {
+	txdrive=rc;
+	txdrv_dbl=(double) txdrive * 0.003921568627;
+	fprintf(stderr,"HP: TX drive= %d (%f)\n", txdrive,txdrv_dbl);
+     }
+     rc=buffer[1400];
+     if (rc != w1400) {
+	w1400=rc;
+	fprintf(stderr,"HP: Xvtr/Audio enable=%x\n", rc);
+     }
+     rc=buffer[1401];
+     if (rc != ocout) {
+	ocout=rc;
+	fprintf(stderr,"HP: OC outputs=%x\n", rc);
+     }
+     rc=buffer[1402];
+     if (rc != db9) {
+	db9=rc;
+	fprintf(stderr,"HP: Outputs DB9=%x\n", rc);
+     }
+     rc=buffer[1403];
+     if (rc != mercury_atts) {
+	mercury_atts=rc;
+	fprintf(stderr,"HP: MercuryAtts=%x\n", rc);
+     }
+     // Store Alex0 and Alex1 bits in separate ints
+     freq=(buffer[1428] << 24) + (buffer[1429] << 16) + (buffer[1430] << 8) + buffer[1431];
+     for (i=0; i<32; i++) {
+	rc=(freq >> i) & 0x01;
+	if (rc != alex1[i]) {
+	    alex1[i]=rc;
+	    fprintf(stderr,"HP: ALEX1 bit%d set to %d\n", i, rc);
+	}
+     }
+     freq=(buffer[1432] << 24) + (buffer[1433] << 16) + (buffer[1434] << 8) + buffer[1435];
+     for (i=0; i<32; i++) {
+	rc=(freq >> i) & 0x01;
+	if (rc != alex0[i]) {
+	    alex0[i]=rc;
+	    fprintf(stderr,"HP: ALEX0 bit%d set to %d\n", i, rc);
+	}
+     }
+     rc=buffer[1442];
+     if (rc != stepatt1) {
+	stepatt1=rc;
+	rxatt1_dbl=pow(10.0, -0.05*stepatt1);
+	fprintf(stderr,"HP: StepAtt1 = %d\n", rc);
+     }
+     rc=buffer[1443];
+     if (rc != stepatt0) {
+	stepatt0=rc;
+	rxatt0_dbl=pow(10.0, -0.05*stepatt0);
+	fprintf(stderr,"HP: StepAtt0 = %d\n", stepatt0);
+     }
+  }
+  return NULL;
+}
+
+void *rx_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  // One instance of this thread is started for each DDC
+  unsigned long seqnum;
+  unsigned char buffer[1444];
+  int yes = 1;
+  int rc;
+  int ddc;
+  int i;
+  unsigned long time;
+  long wait;
+  double i0sample,q0sample;
+  double i1sample,q1sample;
+  double irsample,qrsample;
+  double fac;
+  int sample;
+  unsigned char *p;
+  int noisept;
+  int myddc;
+  long myrate;
+  int sync,size;
+  int myadc, syncadc;
+  int ps=0;
+  int rxptr;
+  
+  struct timespec delay;
+#ifdef __APPLE__
+  struct timespec now;
+#endif
+
+  myddc=(int) (uintptr_t) data;
+  if (myddc < 0 || myddc >= NUMRECEIVERS) return NULL;
+  seqnum=0;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: RXthread: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(ddc0_port+myddc);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: RXthread: bind");
+    return NULL;
+  }
+
+  noisept=0;
+  clock_gettime(CLOCK_MONOTONIC, &delay);
+  fprintf(stderr,"RX thread %d, enabled=%d\n", myddc, ddcenable[myddc]);
+  rxptr=txptr-5000;  
+  if (rxptr < 0) rxptr += NEWRTXLEN;
+  while (run) {
+	if (!ddcenable[myddc] || rxrate[myddc] == 0 || rxfreq[myddc] == 0) {
+	  usleep(5000);
+          clock_gettime(CLOCK_MONOTONIC, &delay);
+	  rxptr=txptr-5000;  
+	  if (rxptr < 0) rxptr += NEWRTXLEN;
+          continue;
+        }
+	myadc=adcmap[myddc];
+        // for simplicity, we only allow for a single "synchronized" DDC,
+        // this well covers the PURESIGNAL and DIVERSITY cases
+	sync=0;
+	i=syncddc[myddc];
+	while (i) {
+	  sync++;
+	  i = i >> 1;
+	}
+	// sync == 0 means no synchronizatsion
+        // sync == 1,2,3  means synchronization with DDC0,1,2
+	// Usually we send 238 samples per buffer, but with synchronization
+	// we send 119 sample *pairs*.
+        if (sync) {
+	  size=119;
+          wait=119000000L/rxrate[myddc]; // time for these samples in nano-secs
+	  syncadc=adcmap[sync-1];
+	} else {
+	  size=238;
+          wait=238000000L/rxrate[myddc]; // time for these samples in nano-secs
+	}
+	//
+	// ADC0: noise   (+ distorted TX signal upon TXing)
+	// ADC1: noise   20 dB stronger
+	// ADC2:         original TX signal (ADC1 on HERMES)
+	//
+	  
+        ps=(sync && (rxrate[myadc]==192) && ptt[0] && (syncadc == adc));
+        p=buffer;
+        *p++ =(seqnum >> 24) & 0xFF;
+        *p++ =(seqnum >> 16) & 0xFF;
+        *p++ =(seqnum >>  8) & 0xFF;
+        *p++ =(seqnum >>  0) & 0xFF;
+        seqnum += 1;
+        // do not use time stamps
+	*p++ = 0;
+	*p++ = 0;
+	*p++ = 0;
+	*p++ = 0;
+	*p++ = 0;
+	*p++ = 0;
+	*p++ = 0;
+	*p++ = 0;
+	// 24 bits per sample *ALWAYS*
+	*p++ = 0;
+	*p++ = 24;
+	*p++ = 0;
+	*p++ = sync ? 2*size : size;  // should be 238 in either case
+	for (i=0; i<size; i++) {
+	  //
+	  // produce noise depending on the ADC
+	  //
+	  i1sample=i0sample=noiseItab[noisept];
+	  q1sample=q0sample=noiseItab[noisept++];
+          if (noisept == LENNOISE) noisept=rand() / NOISEDIV;
+	  if (myadc == 1) {
+	    i0sample=i0sample*10.0;   // 20 dB more noise on ADC1
+	    q0sample=q0sample*10.0;
+          }
+	  //
+	  // PS: produce sample PAIRS,
+	  // a) distorted TX data (with Drive and Attenuation) 
+	  // b) original TX data (normalized)
+	  //
+	  if (ps) {
+	    irsample = isample[rxptr];
+	    qrsample = qsample[rxptr++];
+	    if (rxptr >= NEWRTXLEN) rxptr=0;
+	    fac=txatt_dbl*txdrv_dbl*(IM3a+IM3b*(irsample*irsample+qrsample*qrsample)*txdrv_dbl*txdrv_dbl);
+	    if (myadc == 0) {
+	      i0sample += irsample*fac;
+	      q0sample += qrsample*fac;
+	    }
+	  }
+	  if (sync) {
+	    if (ps) {
+	      // synchronized stream: undistorted TX signal with constant max. amplitude
+	      i1sample = irsample * 0.329;
+	      q1sample = qrsample * 0.329;
+	    }
+	    sample=i0sample * 8388607.0;
+	    *p++=(sample >> 16) & 0xFF;
+	    *p++=(sample >>  8) & 0xFF;
+	    *p++=(sample >>  0) & 0xFF;
+	    sample=q0sample * 8388607.0;
+	    *p++=(sample >> 16) & 0xFF;
+	    *p++=(sample >>  8) & 0xFF;
+	    *p++=(sample >>  0) & 0xFF;
+	    sample=i1sample * 8388607.0;
+	    *p++=(sample >> 16) & 0xFF;
+	    *p++=(sample >>  8) & 0xFF;
+	    *p++=(sample >>  0) & 0xFF;
+	    sample=q1sample * 8388607.0;
+	    *p++=(sample >> 16) & 0xFF;
+	    *p++=(sample >>  8) & 0xFF;
+	    *p++=(sample >>  0) & 0xFF;
+	  } else {
+	    sample=i0sample * 8388607.0;
+	    *p++=(sample >> 16) & 0xFF;
+	    *p++=(sample >>  8) & 0xFF;
+	    *p++=(sample >>  0) & 0xFF;
+	    sample=q0sample * 8388607.0;
+	    *p++=(sample >> 16) & 0xFF;
+	    *p++=(sample >>  8) & 0xFF;
+	    *p++=(sample >>  0) & 0xFF;
+	  }
+        }
+        delay.tv_nsec += wait;
+        while (delay.tv_nsec >= 1000000000) {
+          delay.tv_nsec -= 1000000000;
+          delay.tv_sec++;
+	}
+#ifdef __APPLE__
+        //
+        // The (so-called) operating system for Mac does not have clock_nanosleep(),
+        // but is has clock_gettime as well as nanosleep.
+        // So, to circumvent this problem, we look at the watch and determine
+        // how long we should sleep now.
+        //
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        now.tv_sec =delay.tv_sec  - now.tv_sec;
+        now.tv_nsec=delay.tv_nsec - now.tv_nsec;
+        while (now.tv_nsec < 0) {
+         now.tv_nsec += 1000000000;
+         now.tv_sec--;
+        }
+        nanosleep(&now, NULL);
+#else
+        clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &delay, NULL);
+#endif
+        if (sendto(sock, buffer, 1444, 0, (struct sockaddr*)&addr_new, sizeof(addr_new)) < 0) {
+          perror("***** ERROR: RX thread sendto");
+          break;
+	}
+  }
+  close(sock);
+  return NULL;
+}
+
+//
+// This thread receives data (TX samples) from the PC
+//
+void *tx_thread(void * data) {
+  int sock;
+  struct sockaddr_in addr;
+  socklen_t lenaddr=sizeof(addr);
+  unsigned long seqnum, seqold;
+  unsigned char buffer[1444];
+  int yes = 1;
+  int rc;
+  int i;
+  unsigned char *p;
+  int noisept;
+  int sample;
+  double di,dq;
+  double sum;
+  struct timeval tv;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: TX: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+  tv.tv_sec = 0;
+  tv.tv_usec = 10000;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *)&tv, sizeof(tv));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(duc0_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: TX: bind");
+    return NULL;
+  }
+
+  seqnum=0; 
+  while(run) {
+     rc = recvfrom(sock, buffer, 1444, 0,(struct sockaddr *)&addr, &lenaddr);
+     if (rc < 0 && errno != EAGAIN) {
+       perror("***** ERROR: TX thread: recvmsg");
+       break;
+     }
+     if (rc < 0) continue;
+     if (rc != 1444) {
+       fprintf(stderr,"Received TX packet with incorrect length");
+       break;
+     }
+     seqold = seqnum;
+     seqnum = (buffer[0] << 24) + (buffer[1] << 16) + (buffer[2] << 8) + buffer[3];
+     if (seqnum != 0 &&seqnum != seqold+1 ) {
+       fprintf(stderr,"TXthread: SEQ ERROR, old=%lu new=%lu\n", seqold, seqnum);
+     }
+     p=buffer+4;
+     sum=0.0;
+     for (i=0; i<240; i++) {
+	// process 240 TX iq samples
+        sample  = (int)((signed char) (*p++))<<16;
+        sample |= (int)((((unsigned char)(*p++))<<8)&0xFF00);
+        sample |= (int)((unsigned char)(*p++)&0xFF);
+	di = (double) sample / 8388608.0;
+        sample  = (int)((signed char) (*p++))<<16;
+        sample |= (int)((((unsigned char)(*p++))<<8)&0xFF00);
+        sample |= (int)((unsigned char)(*p++)&0xFF);
+	dq = (double) sample / 8388608.0;
+//
+//      put TX samples into ring buffer
+//
+	isample[txptr]=di;
+	qsample[txptr++]=dq;
+	if (txptr >= NEWRTXLEN) txptr=0;
+//
+//      accumulate TX power
+//
+        sum += (di*di+dq*dq);
+     }
+     txlevel=sum * txdrv_dbl * txdrv_dbl * 0.0041667;
+     fprintf(stderr,"LEV1=%f LEV2=%f\n", sum*0.0041667, txlevel);
+  }
+  return NULL;
+}
+
+void *send_highprio_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  unsigned long seqnum;
+  unsigned char buffer[60];
+  int yes = 1;
+  int rc;
+  int i;
+  unsigned char *p;
+
+
+  seqnum=0;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: SendHighPrio thread: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(shp_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: SendHighPrio thread: bind");
+    return NULL;
+  }
+
+  seqnum=0;
+  while (1) {
+    if (!run) {
+	close(sock);
+	break;
+    }
+    // prepare buffer
+    memset(buffer, 0, 60);
+    p=buffer;
+    *p++ = (seqnum >> 24) & 0xFF;
+    *p++ = (seqnum >> 16) & 0xFF;
+    *p++ = (seqnum >>  8) & 0xFF;
+    *p++ = (seqnum >>  0) & 0xFF;
+    *p++ = 0;    // no PTT and CW attached
+    *p++ = 0;    // no ADC overload
+    *p++ = 1;
+    *p++ = 126;    // 1 W exciter power
+ 
+    p +=6;
+
+    rc=(int) (800.0*sqrt(10*txlevel));    
+    *p++ = (rc >> 8) & 0xFF;
+    *p++ = (rc     ) & 0xFF;
+
+    buffer[49]=63;   // about 13 volts supply 
+
+    if (sendto(sock, buffer, 60, 0, (struct sockaddr*)&addr_new, sizeof(addr_new)) < 0) {
+       perror("***** ERROR: HP send thread sendto");
+       break;
+    }
+    seqnum++;
+    usleep(50000); // wait 50 msec
+  }
+  close(sock);
+  return NULL;
+}
+
+//
+// This thread receives the audio samples and plays them
+//
+void *audio_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  socklen_t lenaddr=sizeof(addr);
+  unsigned long seqnum, seqold;
+  unsigned char buffer[260];
+  int yes = 1;
+  int rc;
+  int i;
+  unsigned char *p;
+  int16_t lsample,rsample;
+  struct timeval tv;
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: Audio: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+  tv.tv_sec = 0;
+  tv.tv_usec = 10000;
+  setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (void *)&tv, sizeof(tv));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(audio_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: Audio: bind");
+    return NULL;
+  }
+
+  seqnum=0;
+  while(run) {
+     rc = recvfrom(sock, buffer, 260, 0,(struct sockaddr *)&addr, &lenaddr);
+     if (rc < 0 && errno != EAGAIN) {
+       perror("***** ERROR: Audio thread: recvmsg");
+       break;
+     }
+     if (rc < 0) continue;
+     if (rc != 260) {
+       fprintf(stderr,"Received Audio packet with incorrect length");
+       break;
+     }
+     seqold = seqnum;
+     seqnum = (buffer[0] << 24) + (buffer[1] << 16) + (buffer[2] << 8) + buffer[3];
+     if (seqnum != 0 &&seqnum != seqold+1 ) {
+       fprintf(stderr,"Audio thread: SEQ ERROR, old=%lu new=%lu\n", seqold, seqnum);
+     }
+     p=buffer+4;
+     for (i=0; i<64; i++) {
+       lsample  = ((signed char) *p++) << 8;	
+       lsample |= (*p++ & 0xff); 
+       rsample  = ((signed char) *p++) << 8;	
+       rsample |= (*p++ & 0xff); 
+       audio_write(lsample,rsample);
+    }
+  }
+  close (sock);
+  return NULL;
+}
+
+//
+// The microphone thread generates
+// a two-tone signal
+//
+void *mic_thread(void *data) {
+  int sock;
+  struct sockaddr_in addr;
+  unsigned long seqnum;
+  unsigned char buffer[132];
+  unsigned char *p;
+  int yes = 1;
+  int rc;
+  int i;
+  double arg1,arg2;
+  int sintab[480];  // microphone data
+  int sinptr = 0;
+  struct timespec delay;
+#ifdef __APPLE__
+  struct timespec now;
+#endif
+
+#define FREQ900  0.11780972450961724644234912687298
+#define FREQ1700 0.22252947962927702105777057298230
+
+  seqnum=0;
+  arg1=0.0;
+  arg2=0.0;
+  for (i=0; i<480; i++) {
+    sintab[i]=(int) round((sin(arg1)+sin(arg2)) * 5000.0);
+    arg1 += FREQ900;
+    arg2 += FREQ1700;
+  }
+
+  sock=socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("***** ERROR: Mic thread: socket");
+    return NULL;
+  }
+
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (void *)&yes, sizeof(yes));
+  setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (void *)&yes, sizeof(yes));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(mic_port);
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("***** ERROR: Mic thread: bind");
+    return NULL;
+  }
+
+  seqnum=0;
+  memset(buffer, 0, 132);
+  clock_gettime(CLOCK_MONOTONIC, &delay);
+  while (run) {
+    // update seq number
+    p=buffer;
+    *p++ = (seqnum >> 24) & 0xFF;
+    *p++ = (seqnum >> 16) & 0xFF;
+    *p++ = (seqnum >>  8) & 0xFF;
+    *p++ = (seqnum >>  0) & 0xFF;
+    seqnum++;
+    // take periodic data from sintab as "microphone samples"
+    for (i=0; i< 64; i++) {
+	rc=sintab[sinptr++];
+        if (sinptr == 480) sinptr=0;
+        *p++ = (rc >> 8)  & 0xff;
+        *p++ = (rc & 0xff);
+    }
+    // 64 samples with 48000 kHz, makes 1333333 nsec
+    delay.tv_nsec += 1333333;
+    while (delay.tv_nsec >= 1000000000) {
+      delay.tv_nsec -= 1000000000;
+      delay.tv_sec++;
+    }
+#ifdef __APPLE__
+    //
+    // The (so-called) operating system for Mac does not have clock_nanosleep(),
+    // but is has clock_gettime as well as nanosleep.
+    // So, to circumvent this problem, we look at the watch and determine
+    // how long we should sleep now.
+    //
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    now.tv_sec =delay.tv_sec  - now.tv_sec;
+    now.tv_nsec=delay.tv_nsec - now.tv_nsec;
+    while (now.tv_nsec < 0) {
+     now.tv_nsec += 1000000000;
+     now.tv_sec--;
+    }
+    nanosleep(&now, NULL);
+#else
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &delay, NULL);
+#endif
+    if (sendto(sock, buffer, 132, 0, (struct sockaddr*)&addr_new, sizeof(addr_new)) < 0) {
+      perror("***** ERROR: Mic thread sendto");
+      break;
+    }
+  }
+  close(sock);
+  return NULL;
+}
+  
+

--- a/old_discovery.c
+++ b/old_discovery.c
@@ -162,7 +162,7 @@ static void discover(struct ifaddrs* iface) {
         interface_addr.sin_port = htons(0); // system assigned port
         if(bind(discovery_socket,(struct sockaddr*)&interface_addr,sizeof(interface_addr))<0) {
             perror("discover: bind socket failed for discovery_socket:");
-            exit(-1);
+            return;
         }
 
         fprintf(stderr,"discover: bound to %s\n",interface_name);
@@ -208,7 +208,7 @@ static void discover(struct ifaddrs* iface) {
 
     if(sendto(discovery_socket,buffer,len,0,(struct sockaddr*)&to_addr,sizeof(to_addr))<0) {
         perror("discover: sendto socket failed for discovery_socket:");
-        exit(-1);
+        return;
     }
 
     // wait for receive thread to complete

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -960,7 +960,7 @@ void ozy_send_buffer() {
     // the feedback signal is routed automatically/internally
     // If feedback is to the second ADC, leave RX1 ANT settings untouched
     //
-    if (isTransmitting() && transmitter->puresignal && receiver[PS_RX_FEEDBACK]->adc == 0) i=receiver[PS_RX_FEEDBACK]->alex_antenna;
+    if (isTransmitting() && transmitter->puresignal) i=receiver[PS_RX_FEEDBACK]->alex_antenna;
 #endif
     switch(i) {
       case 3:  // Alex: RX2 IN, ANAN: EXT1, ANAN7000: still uses internal feedback 
@@ -1224,10 +1224,8 @@ void ozy_send_buffer() {
             output_buffer[C1]|=receiver[0]->adc;			// RX1 bound to ADC of first receiver
             output_buffer[C1]|=(receiver[1]->adc<<2);			// RX2 actually unsused with PURESIGNAL
             output_buffer[C1]|=receiver[1]->adc<<4;			// RX3 bound to ADC of second receiver
-            output_buffer[C1]|=(receiver[PS_RX_FEEDBACK]->adc<<6);	// RX4 is PS_RX_Feedbacka
-									// Usually ADC0, but if feedback is to
-									// RX2 input it must be ADC1 (see ps_menu.c)
-	    // RX5 is hard-wired to the TX DAC and needs no ADC setting.
+            								// RX4 is PS_RX_Feedback and bound to ADC0
+	    								// RX5 is hard-wired to the TX DAC and needs no ADC setting.
 	}
 #else
         output_buffer[C1]|=receiver[0]->adc;
@@ -1277,16 +1275,6 @@ void ozy_send_buffer() {
         output_buffer[C1]=0x00;
 
         if(isTransmitting()) {
-#ifdef PURESIGNAL
-	  // If we are using the RX2 jack for PURESIGNAL RX feedback, then we MUST NOT ground
-	  // the ADC2 input upon TX.
-	  if (transmitter->puresignal && receiver[PS_RX_FEEDBACK]->adc == 1) {
-	    // Note that this statement seems to have no effect since
-	    // one cannot goto to "manual filter setting" for the ALEX2 board individually
-            output_buffer[C1]|=0x40; // Set ADC2 filter board to "ByPass"
-	  } else
-#endif
-
             output_buffer[C1]|=0x80; // ground RX2 on transmit, bit0-6 are Alex2 filters
         }
         output_buffer[C2]=0x00;

--- a/property.c
+++ b/property.c
@@ -47,16 +47,19 @@ void loadProperties(char* filename) {
             if(string[0]!='#') {
                 name=strtok(string,"=");
                 value=strtok(NULL,"\n");
-                property=malloc(sizeof(PROPERTY));
-                property->name=malloc(strlen(name)+1);
-                strcpy(property->name,name);
-                property->value=malloc(strlen(value)+1);
-                strcpy(property->value,value);
-                property->next_property=properties;
-                properties=property;
-                if(strcmp(name,"property_version")==0) {
-                  version=atof(value);
-                }
+		// Beware of "illegal" lines in corrupted files
+		if (name != NULL && value != NULL) {
+                  property=malloc(sizeof(PROPERTY));
+                  property->name=malloc(strlen(name)+1);
+                  strcpy(property->name,name);
+                  property->value=malloc(strlen(value)+1);
+                  strcpy(property->value,value);
+                  property->next_property=properties;
+                  properties=property;
+                  if(strcmp(name,"property_version")==0) {
+                    version=atof(value);
+                  }
+		}
             }
         }
         fclose(f);

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -240,6 +240,9 @@ static int info_thread(gpointer arg) {
             if (transmitter->attenuation != new_att) {
               SetPSControl(transmitter->id, 1, 0, 0, 0);
 	      transmitter->attenuation=new_att;
+	      if (protocol == NEW_PROTOCOL) {
+		schedule_transmit_specific();
+	      }
               state=1;
 	    }
           }
@@ -267,12 +270,7 @@ static void ps_ant_cb(GtkWidget *widget, gpointer data) {
       case 0:	// AUTO (Internal), feedback goes to first ADC
       case 3:	// EXT1,            feedback goes to first ADC
       case 4:	// EXT2,            feedback goes to first ADC
-	receiver[PS_RX_FEEDBACK]->alex_antenna = (int) (uintptr_t) data;
-	receiver[PS_RX_FEEDBACK]->adc              = 0;
-	break;
-      case 99:	// RX2,              feedback goes to second ADC
-	receiver[PS_RX_FEEDBACK]->alex_antenna = 0;
-	receiver[PS_RX_FEEDBACK]->adc              = 1;
+	receiver[PS_RX_FEEDBACK]->alex_antenna = val;
 	break;
     }
   }
@@ -428,7 +426,7 @@ void ps_menu(GtkWidget *parent) {
 
   GtkWidget *ps_ant_auto=gtk_radio_button_new_with_label(NULL,"AUTO");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (ps_ant_auto), 
-    (receiver[PS_RX_FEEDBACK]->alex_antenna == 0) && (receiver[PS_RX_FEEDBACK]->adc == 0));
+    (receiver[PS_RX_FEEDBACK]->alex_antenna == 0) );
   gtk_widget_show(ps_ant_auto);
   gtk_grid_attach(GTK_GRID(grid), ps_ant_auto, col, row, 1, 1);
   g_signal_connect(ps_ant_auto,"toggled", G_CALLBACK(ps_ant_cb), (gpointer) (long) 0);
@@ -436,7 +434,7 @@ void ps_menu(GtkWidget *parent) {
 
   GtkWidget *ps_ant_ext1=gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(ps_ant_auto),"EXT1");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (ps_ant_ext1),
-    (receiver[PS_RX_FEEDBACK]->alex_antenna==3) && (receiver[PS_RX_FEEDBACK]->adc == 0));
+    (receiver[PS_RX_FEEDBACK]->alex_antenna==3) );
   gtk_widget_show(ps_ant_ext1);
   gtk_grid_attach(GTK_GRID(grid), ps_ant_ext1, col, row, 1, 1);
   g_signal_connect(ps_ant_ext1,"toggled", G_CALLBACK(ps_ant_cb), (gpointer) (long) 3);
@@ -444,20 +442,11 @@ void ps_menu(GtkWidget *parent) {
 
   GtkWidget *ps_ant_ext2=gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(ps_ant_auto),"EXT2");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (ps_ant_ext2),
-    (receiver[PS_RX_FEEDBACK]->alex_antenna==4) && (receiver[PS_RX_FEEDBACK]->adc == 0));
+    (receiver[PS_RX_FEEDBACK]->alex_antenna==4) );
   gtk_widget_show(ps_ant_ext2);
   gtk_grid_attach(GTK_GRID(grid), ps_ant_ext2, col, row, 1, 1);
   g_signal_connect(ps_ant_ext2,"toggled", G_CALLBACK(ps_ant_cb), (gpointer) (long) 4);
   col++;
-
-  if (n_adc > 1) {
-    // If there are two ADCs, we may choose to use the second ADC for PS_RX_FEEDBACK
-    GtkWidget *ps_ant_rx2=gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(ps_ant_auto),"RX2");
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (ps_ant_rx2), receiver[PS_RX_FEEDBACK]->adc==1);
-    gtk_widget_show(ps_ant_rx2);
-    gtk_grid_attach(GTK_GRID(grid), ps_ant_rx2, col, row, 1, 1);
-    g_signal_connect(ps_ant_rx2,"toggled", G_CALLBACK(ps_ant_cb), (gpointer) (long) 99);
-  }
 
   row++;
 

--- a/radio.c
+++ b/radio.c
@@ -748,6 +748,9 @@ void radio_change_sample_rate(int rate) {
         for(i=0;i<receivers;i++) {
           receiver_change_sample_rate(receiver[i],rate);
         }
+#ifdef PURESIGNAL
+        receiver_change_sample_rate(receiver[PS_RX_FEEDBACK],rate);
+#endif
         old_protocol_set_mic_sample_rate(rate);
         old_protocol_run();
 #ifdef PURESIGNAL

--- a/radio.c
+++ b/radio.c
@@ -370,7 +370,8 @@ void start_radio() {
 #endif
 
 #ifdef __APPLE__
-  property_sem=sem_open("PROPERTY", O_CREAT, 0700, 0);
+  sem_unlink("PROPERTY");
+  property_sem=sem_open("PROPERTY", O_CREAT | O_EXCL, 0700, 0);
   rc=(property_sem == SEM_FAILED);
 #else
   rc=sem_init(&property_sem, 0, 0);
@@ -598,6 +599,7 @@ void start_radio() {
   tx_set_ps_sample_rate(transmitter,protocol==NEW_PROTOCOL?192000:active_receiver->sample_rate);
   receiver[PS_TX_FEEDBACK]=create_pure_signal_receiver(PS_TX_FEEDBACK, buffer_size,protocol==ORIGINAL_PROTOCOL?active_receiver->sample_rate:192000,display_width);
   receiver[PS_RX_FEEDBACK]=create_pure_signal_receiver(PS_RX_FEEDBACK, buffer_size,protocol==ORIGINAL_PROTOCOL?active_receiver->sample_rate:192000,display_width);
+  SetPSHWPeak(transmitter->id, protocol==ORIGINAL_PROTOCOL? 0.4067 : 0.2899);
 #endif
 
 #ifdef AUDIO_WATERFALL
@@ -793,10 +795,6 @@ static void rxtx(int state) {
       SetChannelState(receiver[i]->id,0,i==(receivers-1));
 #endif
       set_displaying(receiver[i],0);
-      if(protocol==NEW_PROTOCOL) {
-        schedule_high_priority();
-        schedule_receive_specific();
-      }
       g_object_ref((gpointer)receiver[i]->panel);
       g_object_ref((gpointer)receiver[i]->panadapter);
       if(receiver[i]->waterfall!=NULL) {
@@ -815,10 +813,6 @@ static void rxtx(int state) {
   } else {
     // switch to rx
     SetChannelState(transmitter->id,0,1);
-    if(protocol==NEW_PROTOCOL) {
-      schedule_high_priority();
-      schedule_receive_specific();
-    }
     tx_set_displaying(transmitter,0);
     g_object_ref((gpointer)transmitter->panel);
     g_object_ref((gpointer)transmitter->panadapter);
@@ -851,13 +845,17 @@ void setMox(int state) {
   vox_cancel();  // remove time-out
   if(mox!=state) {
     if (state && vox) {
-      // Suppress RX-TX transition if VOX was active
+      // Suppress RX-TX transition if VOX was already active
     } else {
       rxtx(state);
     }
     mox=state;
   }
   vox=0;
+  if(protocol==NEW_PROTOCOL) {
+      schedule_high_priority();
+      schedule_receive_specific();
+  }
 }
 
 int getMox() {
@@ -869,6 +867,10 @@ void vox_changed(int state) {
     rxtx(state);
   }
   vox=state;
+  if(protocol==NEW_PROTOCOL) {
+      schedule_high_priority();
+      schedule_receive_specific();
+  }
 }
 
 
@@ -978,6 +980,10 @@ void setTune(int state) {
     }
     tune=state;
   }
+  if(protocol==NEW_PROTOCOL) {
+    schedule_high_priority();
+    schedule_receive_specific();
+  }
 }
 
 int getTune() {
@@ -1076,7 +1082,7 @@ static int calcLevel(double d) {
 
 void calcDriveLevel() {
     transmitter->drive_level=calcLevel(transmitter->drive);
-    if(mox && protocol==NEW_PROTOCOL) {
+    if(isTransmitting()  && protocol==NEW_PROTOCOL) {
       schedule_high_priority();
     }
 //fprintf(stderr,"calcDriveLevel: drive=%d drive_level=%d\n",transmitter->drive,transmitter->drive_level);

--- a/receiver.c
+++ b/receiver.c
@@ -165,6 +165,18 @@ void receiver_save_state(RECEIVER *rx) {
   char name[128];
   char value[128];
 
+  sprintf(name,"receiver.%d.alex_antenna",rx->id);
+  sprintf(value,"%d",rx->alex_antenna);
+  setProperty(name,value);
+
+#ifdef PURESIGNAL
+  //
+  // for PS_RX_RECEIVER, *only* save the ALEX antenna setting
+  // and then return quickly.
+  //
+  if (rx->id == PS_RX_FEEDBACK) return;
+#endif
+
   sprintf(name,"receiver.%d.sample_rate",rx->id);
   sprintf(value,"%d",rx->sample_rate);
   setProperty(name,value);
@@ -199,9 +211,6 @@ void receiver_save_state(RECEIVER *rx) {
   sprintf(value,"%d",rx->waterfall_automatic);
   setProperty(name,value);
   
-  sprintf(name,"receiver.%d.alex_antenna",rx->id);
-  sprintf(value,"%d",rx->alex_antenna);
-  setProperty(name,value);
   sprintf(name,"receiver.%d.alex_attenuation",rx->id);
   sprintf(value,"%d",rx->alex_attenuation);
   setProperty(name,value);
@@ -304,6 +313,18 @@ void receiver_restore_state(RECEIVER *rx) {
   char *value;
 
 fprintf(stderr,"receiver_restore_state: id=%d\n",rx->id);
+  sprintf(name,"receiver.%d.alex_antenna",rx->id);
+  value=getProperty(name);
+  if(value) rx->alex_antenna=atoi(value);
+
+#ifdef PURESIGNAL
+  //
+  // for PS_RX_RECEIVER, *only* restore the ALEX antenna and setting
+  // and then return quickly
+  //
+  if (rx->id == PS_RX_FEEDBACK) return;
+#endif
+
   sprintf(name,"receiver.%d.sample_rate",rx->id);
   value=getProperty(name);
   if(value) rx->sample_rate=atoi(value);
@@ -355,9 +376,6 @@ fprintf(stderr,"receiver_restore_state: id=%d\n",rx->id);
   value=getProperty(name);
   if(value) rx->waterfall_automatic=atoi(value);
 
-  sprintf(name,"receiver.%d.alex_antenna",rx->id);
-  value=getProperty(name);
-  if(value) rx->alex_antenna=atoi(value);
   sprintf(name,"receiver.%d.alex_attenuation",rx->id);
   value=getProperty(name);
   if(value) rx->alex_attenuation=atoi(value);
@@ -738,13 +756,14 @@ fprintf(stderr,"create_pure_signal_receiver: id=%d buffer_size=%d\n",id,buffer_s
   RECEIVER *rx=malloc(sizeof(RECEIVER));
   rx->id=id;
 
-  rx->ddc=4;
-  rx->adc=0;  // one more than actual adc
+  // Note that fixed DDC/ADC settings are used in old_protocol and new_protocol.
+  rx->ddc=0;   // unused in old protocol
+  rx->adc=0;
 
   rx->sample_rate=sample_rate;
   rx->buffer_size=buffer_size;
   rx->fft_size=fft_size;
-  rx->pixels=pixels;   // need this for the "MON" button
+  rx->pixels=0;
   rx->fps=0;
 
   rx->width=0;
@@ -752,12 +771,22 @@ fprintf(stderr,"create_pure_signal_receiver: id=%d buffer_size=%d\n",id,buffer_s
   rx->display_panadapter=0;
   rx->display_waterfall=0;
 
+  if (id == PS_RX_FEEDBACK) {
+    //
+    // need a buffer for pixels for the spectrum of the feedback
+    // signal (MON button).
+    // NewProtocol: Since we want to display only 48 kHz instead of
+    // 192 kHz, we make a spectrum with four times the pixels and then
+    // display only the central part.
+    // 
+    rx->pixels = (protocol == ORIGINAL_PROTOCOL) ? pixels : 4*pixels;
+  }
   // allocate buffers
   rx->iq_sequence=0;
   rx->iq_input_buffer=malloc(sizeof(double)*2*rx->buffer_size);
   rx->audio_buffer=NULL;
   rx->audio_sequence=0L;
-  rx->pixel_samples=malloc(sizeof(float)*pixels);
+  rx->pixel_samples=malloc(sizeof(float)*(rx->pixels));
 
   rx->samples=0;
   rx->displaying=0;


### PR DESCRIPTION
a) MacOS stuff
==============

- Adapted Info.plist to MacOS 10.14 (Mojave) to allow for
  sound input devices.

- reworked semaphore stuff (unlinking named semaphores before
  creating them).

- "app" bundle now uses $HOME/.phipsdr as work directory

- README.MacOS: included instructions how to use a pre-compiled app bundle
  (loading GTK+3 environment from homebrew)

b) HPSDR simulator
==================

extended to new protocol (P2).


c) NewProtocol PURESIGNAL
=========================

many corrections


d) Further corrections
======================

- made new_protocol thread-safe (using mutex-es)
- do not choke on non-functional network cards
  (discovery), simply try the next one.
- removed option to use RX2 input for PS feedback
- ignore malformed property lines
- P2: schedule HighPrio and RXspecific packet *after* RX/TX
  switching is complete
- P2: allow drive level changes while VOX or TUNE is active
- receiver save/restore: save *only* alex_antenna for PS_RX_FEEDBACK
- P1: making TX feedback spectrum "high resolution" at all sample
  rates
