### PR TITLE
My recent updates. From my side, all OK for "release date"

### DIFF
--- a/agc_menu.c
+++ b/agc_menu.c
@@ -32,6 +32,7 @@
 #include "receiver.h"
 #include "vfo.h"
 #include "button_text.h"
+#include "ext.h"
 
 static GtkWidget *parent_window=NULL;
 
@@ -59,7 +60,7 @@ static void agc_select_cb (GtkToggleButton *widget, gpointer        data) {
   if(gtk_toggle_button_get_active(widget)) {
     active_receiver->agc=GPOINTER_TO_INT(data);
     set_agc(active_receiver, active_receiver->agc);
-    vfo_update();
+    g_idle_add(ext_vfo_update, NULL);
   }
 }
 

--- a/alsa_midi.c
+++ b/alsa_midi.c
@@ -233,6 +233,7 @@ void register_midi_device(char *myname) {
     }
     if (!found) {
 	fprintf(stderr,"MIDI device %s NOT FOUND!\n", myname);
+        return;
     }
     // Found our MIDI input device. Spawn off a thread reading data
     ret = pthread_create(&midi_thread_id, NULL, midi_thread, NULL);

--- a/audio.c
+++ b/audio.c
@@ -398,14 +398,10 @@ int audio_write(RECEIVER *rx,float left_sample,float right_sample) {
   snd_pcm_sframes_t delay;
   long rc;
   long trim;
-  int mode=modeUSB;
+  int txmode=get_tx_mode();
   float *float_buffer;
   gint32 *long_buffer;
   gint16 *short_buffer;
-
-  if(can_transmit) {
-    mode=transmitter->mode;
-  }
 
   //
   // We have to stop the stream here if a CW side tone may occur.
@@ -416,7 +412,7 @@ int audio_write(RECEIVER *rx,float left_sample,float right_sample) {
   // to listen to this rx while transmitting.
   //
 
-  if (rx == active_receiver && isTransmitting() && (mode==modeCWU || mode==modeCWL)) {
+  if (rx == active_receiver && isTransmitting() && (txmode==modeCWU || txmode==modeCWL)) {
     return 0;
   }
 

--- a/audio.c
+++ b/audio.c
@@ -46,6 +46,7 @@
 #ifdef SOAPYSDR
 #include "soapy_protocol.h"
 #endif
+#include "vfo.h"
 
 int audio = 0;
 int mic_buffer_size = 720; // samples (both left and right)

--- a/cw_menu.c
+++ b/cw_menu.c
@@ -271,7 +271,7 @@ void cw_menu(GtkWidget *parent) {
   g_signal_connect(cw_keyer_weight_b,"value_changed",G_CALLBACK(cw_keyer_weight_value_changed_cb),NULL);
 
 #ifdef LOCALCW
-  GtkWidget *cw_keyer_internal_b=gtk_check_button_new_with_label("CW Internal");
+  GtkWidget *cw_keyer_internal_b=gtk_check_button_new_with_label("CW handled in Radio");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (cw_keyer_internal_b), cw_keyer_internal);
   gtk_widget_show(cw_keyer_internal_b);
   gtk_grid_attach(GTK_GRID(grid),cw_keyer_internal_b,0,10,1,1);

--- a/cw_menu.c
+++ b/cw_menu.c
@@ -124,7 +124,8 @@ static void cw_keyer_sidetone_level_value_changed_cb(GtkWidget *widget, gpointer
 static void cw_keyer_sidetone_frequency_value_changed_cb(GtkWidget *widget, gpointer data) {
   cw_keyer_sidetone_frequency=gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(widget));
 /*
-  if(transmitter->mode==modeCWL || transmitter->mode==modeCWU) {
+  int txmode=get_tx_mode();
+  if(txmode==modeCWL || txmode==modeCWU) {
     BANDSTACK_ENTRY *entry=bandstack_entry_get_current();
     FILTER* band_filters=filters[entry->mode];
     FILTER* band_filter=&band_filters[entry->filter];

--- a/discovered.h
+++ b/discovered.h
@@ -30,28 +30,29 @@
 
 // ANAN 7000DLE and 8000DLE uses 10 as the device type in old protocol
 // Newer STEMlab hpsdr emulators use 100 instead of 1
-#define DEVICE_METIS          0
-#define DEVICE_HERMES         1
-#define DEVICE_GRIFFIN        2
-#define DEVICE_ANGELIA        4
-#define DEVICE_ORION          5
-#define DEVICE_HERMES_LITE    6
-#define DEVICE_HERMES_LITE2   7
-#define DEVICE_ORION2        10 
-#define DEVICE_STEMLAB      100
+// HermesLite V2 uses V1 board ID and software version >= 40
+#define DEVICE_METIS           0
+#define DEVICE_HERMES          1
+#define DEVICE_GRIFFIN         2
+#define DEVICE_ANGELIA         4
+#define DEVICE_ORION           5
+#define DEVICE_HERMES_LITE     6
+#define DEVICE_HERMES_LITE2 1006
+#define DEVICE_ORION2         10 
+#define DEVICE_STEMLAB       100
 
 #ifdef USBOZY
 #define DEVICE_OZY 7
 #endif
 
-#define NEW_DEVICE_ATLAS        0
-#define NEW_DEVICE_HERMES       1
-#define NEW_DEVICE_HERMES2      2
-#define NEW_DEVICE_ANGELIA      3
-#define NEW_DEVICE_ORION        4
-#define NEW_DEVICE_ORION2       5
-#define NEW_DEVICE_HERMES_LITE  6
-#define NEW_DEVICE_HERMES_LITE2 7
+#define NEW_DEVICE_ATLAS           0
+#define NEW_DEVICE_HERMES          1
+#define NEW_DEVICE_HERMES2         2
+#define NEW_DEVICE_ANGELIA         3
+#define NEW_DEVICE_ORION           4
+#define NEW_DEVICE_ORION2          5
+#define NEW_DEVICE_HERMES_LITE     6
+#define NEW_DEVICE_HERMES_LITE2 1006
 
 #ifdef SOAPYSDR
 #define SOAPYSDR_USB_DEVICE 0

--- a/diversity_menu.c
+++ b/diversity_menu.c
@@ -28,6 +28,7 @@
 #include "diversity_menu.h"
 #include "radio.h"
 #include "new_protocol.h"
+#include "old_protocol.h"
 #include "sliders.h"
 
 #include <math.h> 

--- a/diversity_menu.c
+++ b/diversity_menu.c
@@ -30,6 +30,7 @@
 #include "new_protocol.h"
 #include "old_protocol.h"
 #include "sliders.h"
+#include "ext.h"
 
 #include <math.h> 
 
@@ -78,6 +79,7 @@ static void diversity_cb(GtkWidget *widget, gpointer data) {
     schedule_high_priority();
     schedule_receive_specific();
   }
+  g_idle_add(ext_vfo_update, NULL);
 }
 
 //

--- a/diversity_menu.c
+++ b/diversity_menu.c
@@ -61,7 +61,18 @@ static gboolean delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_d
 }
 
 static void diversity_cb(GtkWidget *widget, gpointer data) {
+  //
+  // If we have only one receiver, then changing diversity
+  // changes the number of HPSR receivers so we restart the
+  // original protocol
+  //
+  if (protocol == ORIGINAL_PROTOCOL && receivers == 1) {
+    old_protocol_stop();
+  }
   diversity_enabled=diversity_enabled==1?0:1;
+  if (protocol == ORIGINAL_PROTOCOL && receivers == 1) {
+    old_protocol_run();
+  }
   if (protocol == NEW_PROTOCOL) {
     schedule_high_priority();
     schedule_receive_specific();

--- a/ext.h
+++ b/ext.h
@@ -63,7 +63,7 @@ extern int ext_b_to_a(void *data);
 extern int ext_a_swap_b(void *data);
 extern int ext_ctun_update(void *data);
 extern int ext_agc_update(void *data);
-extern int ext_split_update(void *data);
+extern int ext_split_toggle(void *data);
 
 
 extern int ext_cw_setup();

--- a/gpio.c
+++ b/gpio.c
@@ -526,7 +526,7 @@ static int e_function_pressed(void *data) {
       g_idle_add(ext_agc_update,NULL);
       break;
     case SPLIT:
-      if(can_transmit) g_idle_add(ext_split_update,NULL);
+      if(can_transmit) g_idle_add(ext_split_toggle,NULL);
       break;
     case DIVERSITY:
       g_idle_add(ext_diversity_update,GINT_TO_POINTER(0));

--- a/hpsdrsim.c
+++ b/hpsdrsim.c
@@ -762,6 +762,10 @@ int main(int argc, char *argv[])
 				  buffer[20]=2;
 				  buffer[21]=1;
 				  buffer[22]=3;
+				  // HERMES_LITE2 is a HermesLite with a new software version
+				  if (NEWDEVICE == NEW_DEVICE_HERMES_LITE2) {
+				    buffer[11]=NEW_DEVICE_HERMES_LITE;
+				  }
 				  sendto(sock_udp, buffer, 60, 0, (struct sockaddr *)&addr_from, sizeof(addr_from));
 				  break;
 				}

--- a/hpsdrsim.h
+++ b/hpsdrsim.h
@@ -22,7 +22,7 @@
 #define DEVICE_ANGELIA         4
 #define DEVICE_ORION           5
 #define DEVICE_HERMES_LITE     6
-#define DEVICE_HERMES_LITE2    7
+#define DEVICE_HERMES_LITE2 1006
 #define DEVICE_ORION2         10
 #define DEVICE_C25           100
 
@@ -33,7 +33,7 @@
 #define NEW_DEVICE_ORION        4
 #define NEW_DEVICE_ORION2       5
 #define NEW_DEVICE_HERMES_LITE  6
-#define NEW_DEVICE_HERMES_LITE2 7
+#define NEW_DEVICE_HERMES_LITE2 1006
 
 EXTERN int OLDDEVICE;
 EXTERN int NEWDEVICE;

--- a/i2c.c
+++ b/i2c.c
@@ -271,7 +271,7 @@ void i2c_interrupt() {
             g_idle_add(ext_agc_update,NULL);
             break;
           case SPLIT:
-            if(can_transmit) g_idle_add(ext_split_update,NULL);
+            if(can_transmit) g_idle_add(ext_split_toggle,NULL);
             break;
           case DIVERSITY:
             g_idle_add(ext_diversity_update,GINT_TO_POINTER(0));

--- a/iambic.c
+++ b/iambic.c
@@ -376,7 +376,7 @@ static void* keyer_thread(void *arg) {
 	// swallow any cw_events posted during the last "cw hang" time.
         if (!kcwl && !kcwr) continue;
 
-        if (!mox) {
+        if (!mox && cw_breakin) {
           g_idle_add(ext_mox_update, (gpointer)(long) 1);
           // Wait for mox, that is, wait for WDSP shutting down the RX and
           // firing up the TX. This induces a small delay when hitting the key for

--- a/iambic.c
+++ b/iambic.c
@@ -215,6 +215,8 @@
 #include "iambic.h"
 #include "transmitter.h"
 #include "ext.h"
+#include "mode.h"
+#include "vfo.h"
 
 static void* keyer_thread(void *arg);
 static pthread_t keyer_thread_id;
@@ -352,6 +354,7 @@ static void* keyer_thread(void *arg) {
     int i;
     int kdelay;
     int old_volume;
+    int txmode;
 #ifdef __APPLE__
     struct timespec now;
 #endif
@@ -376,7 +379,9 @@ static void* keyer_thread(void *arg) {
 	// swallow any cw_events posted during the last "cw hang" time.
         if (!kcwl && !kcwr) continue;
 
-        if (!mox && cw_breakin) {
+	// check mode: to not induce RX/TX transition if not in CW mode
+        txmode=get_tx_mode();
+        if (!mox && cw_breakin && (txmode == modeCWU || txmode == modeCWL)) {
           g_idle_add(ext_mox_update, (gpointer)(long) 1);
           // Wait for mox, that is, wait for WDSP shutting down the RX and
           // firing up the TX. This induces a small delay when hitting the key for

--- a/midi3.c
+++ b/midi3.c
@@ -234,7 +234,7 @@ void DoTheMidi(enum MIDIaction action, enum MIDItype type, int val) {
 	    break;
 	/////////////////////////////////////////////////////////// "DUP"
         case MIDI_DUP:
-	    if (can_transmit) {
+	    if (can_transmit && !isTransmitting()) {
 	      duplex=duplex==1?0:1;
               g_idle_add(ext_set_duplex, NULL);
 	    }

--- a/midi3.c
+++ b/midi3.c
@@ -582,14 +582,7 @@ void DoTheMidi(enum MIDIaction action, enum MIDItype type, int val) {
 	case MIDI_SPLIT: // only key supported
 	    // toggle split mode
 	    if (type == MIDI_KEY) {
-	      if(!split) {
-		split=1;
-		tx_set_mode(transmitter,vfo[VFO_B].mode);
-	      } else {
-		split=0;
-		tx_set_mode(transmitter,vfo[VFO_A].mode);
-	      }
-	      g_idle_add(ext_vfo_update, NULL);
+              g_idle_add(ext_split_toggle, NULL);
 	    }
 	    break;
 	/////////////////////////////////////////////////////////// "SWAPRX"

--- a/new_discovery.c
+++ b/new_discovery.c
@@ -217,6 +217,8 @@ gpointer new_discover_receive_thread(gpointer data) {
                 if(devices<MAX_DEVICES) {
                     discovered[devices].protocol=NEW_PROTOCOL;
                     discovered[devices].device=buffer[11]&0xFF;
+                    discovered[devices].software_version=buffer[13]&0xFF;
+                    discovered[devices].status=status;
                     switch(discovered[devices].device) {
 			case NEW_DEVICE_ATLAS:
                             strcpy(discovered[devices].name,"Atlas");
@@ -249,12 +251,12 @@ gpointer new_discover_receive_thread(gpointer data) {
                             frequency_max=61440000.0;
                             break;
 			case NEW_DEVICE_HERMES_LITE:
-                            strcpy(discovered[devices].name,"Hermes Lite");
-                            frequency_min=0.0;
-                            frequency_max=30720000.0;
-                            break;
-			case NEW_DEVICE_HERMES_LITE2:
-                            strcpy(discovered[devices].name,"Hermes Lite 2");
+			    if (discovered[devices].software_version < 40) {
+                              strcpy(discovered[devices].name,"Hermes Lite V1");
+			    } else {
+                              strcpy(discovered[devices].name,"Hermes Lite V2");
+			      discovered[devices].device = NEW_DEVICE_HERMES_LITE2;
+			    }
                             frequency_min=0.0;
                             frequency_max=30720000.0;
                             break;
@@ -264,11 +266,9 @@ gpointer new_discover_receive_thread(gpointer data) {
                             frequency_max=30720000.0;
                             break;
                     }
-                    discovered[devices].software_version=buffer[13]&0xFF;
                     for(i=0;i<6;i++) {
                         discovered[devices].info.network.mac_address[i]=buffer[i+5];
                     }
-                    discovered[devices].status=status;
                     memcpy((void*)&discovered[devices].info.network.address,(void*)&addr,sizeof(addr));
                     discovered[devices].info.network.address_length=sizeof(addr);
                     memcpy((void*)&discovered[devices].info.network.interface_address,(void*)&interface_addr,sizeof(interface_addr));

--- a/new_protocol.c
+++ b/new_protocol.c
@@ -745,7 +745,8 @@ static void new_protocol_high_priority() {
 //  Set DUC frequency
 //
 
-    txFrequency=vfo[txvfo].frequency-vfo[txvfo].lo+vfo[txvfo].offset;
+    txFrequency=vfo[txvfo].frequency-vfo[txvfo].lo;
+    if (vfo[txvfo].ctun) txFrequency += vfo[txvfo].offset;
     if(transmitter->xit_enabled) {
       txFrequency+=transmitter->xit;
     }

--- a/new_protocol.c
+++ b/new_protocol.c
@@ -573,13 +573,10 @@ g_print("iq_addr=%s\n",inet_ntoa(radio->info.network.address.sin_addr));
 static void new_protocol_general() {
     BAND *band;
     int rc;
+    int txvfo=get_tx_vfo();
 
     pthread_mutex_lock(&general_mutex);
-    if(split) {
-      band=band_get_band(vfo[VFO_B].band);
-    } else {
-      band=band_get_band(vfo[VFO_A].band);
-    }
+    band=band_get_band(vfo[txvfo].band);
     memset(general_buffer, 0, sizeof(general_buffer));
 
     general_buffer[0]=general_sequence>>24;
@@ -633,9 +630,9 @@ static void new_protocol_high_priority() {
     long long rxFrequency;
     long long txFrequency;
     long phase;
-    int txmode;
     int ddc;
-    int txvfo;
+    int txvfo=get_tx_vfo();
+    int txmode=get_tx_mode();
 
     if(data_socket==-1) {
       return;
@@ -648,25 +645,6 @@ static void new_protocol_high_priority() {
     high_priority_buffer_to_radio[1]=high_priority_sequence>>16;
     high_priority_buffer_to_radio[2]=high_priority_sequence>>8;
     high_priority_buffer_to_radio[3]=high_priority_sequence;
-
-    //
-    // Determine VFO controlling the TX frequency
-    // and the associated mode
-    //
-    if(active_receiver->id==VFO_A) {
-      if(split) {
-        txvfo=VFO_B;
-      } else {
-	txvfo=VFO_A;
-      }
-    } else {
-      if(split) {
-        txvfo=VFO_A;
-      } else {
-	txvfo=VFO_B;
-      }
-    }
-    txmode=vfo[txvfo].mode;
 
     high_priority_buffer_to_radio[4]=running;
 //
@@ -794,12 +772,7 @@ static void new_protocol_high_priority() {
     high_priority_buffer_to_radio[345]=power&0xFF;
 
     if(isTransmitting()) {
-
-      if(split) {
-        band=band_get_band(vfo[VFO_B].band);
-      } else {
-        band=band_get_band(vfo[VFO_A].band);
-      }
+      band=band_get_band(vfo[txvfo].band);
       high_priority_buffer_to_radio[1401]=band->OCtx<<1;
       if(tune) {
         if(OCmemory_tune_time!=0) {
@@ -1142,7 +1115,7 @@ static void new_protocol_high_priority() {
 static unsigned char last_50=0;
 
 static void new_protocol_transmit_specific() {
-    int mode;
+    int txmode=get_tx_mode();
     int rc;
 
     pthread_mutex_lock(&tx_spec_mutex);
@@ -1153,15 +1126,10 @@ static void new_protocol_transmit_specific() {
     transmit_specific_buffer[2]=tx_specific_sequence>>8;
     transmit_specific_buffer[3]=tx_specific_sequence;
 
-    if(split) {
-      mode=vfo[1].mode;
-    } else {
-      mode=vfo[0].mode;
-    }
     transmit_specific_buffer[4]=1; // 1 DAC
     transmit_specific_buffer[5]=0; //  default no CW
 
-    if ((mode==modeCWU || mode==modeCWL) && cw_keyer_internal) {
+    if ((txmode==modeCWU || txmode==modeCWL) && cw_keyer_internal) {
       //
       // Set this byte only if in CW, and if using the "internal" keyer
       //
@@ -1789,10 +1757,6 @@ static void process_high_priority(unsigned char *buffer) {
 #endif
     }
 
-    //int tx_vfo=split?VFO_B:VFO_A;
-    //if(vfo[tx_vfo].mode==modeCWL || vfo[tx_vfo].mode==modeCWU) {
-    //  local_ptt=local_ptt|dot|dash;
-    //}
     if(previous_ptt!=local_ptt) {
       g_idle_add(ext_mox_update,(gpointer)(long)(local_ptt));
     }
@@ -1830,10 +1794,10 @@ static void process_mic_data(int bytes) {
 
 void new_protocol_cw_audio_samples(short left_audio_sample,short right_audio_sample) {
   int rc;
-  int mode=transmitter->mode;
+  int txmode=get_tx_mode();
   //
   // Only process samples if transmitting in CW
-  if (isTransmitting() && (mode==modeCWU || mode==modeCWL)) {
+  if (isTransmitting() && (txmode==modeCWU || txmode==modeCWL)) {
 
   // insert the samples
   audiobuffer[audioindex++]=left_audio_sample>>8;
@@ -1864,10 +1828,10 @@ void new_protocol_cw_audio_samples(short left_audio_sample,short right_audio_sam
 
 void new_protocol_audio_samples(RECEIVER *rx,short left_audio_sample,short right_audio_sample) {
   int rc;
-  int mode=transmitter->mode;
+  int txmode=get_tx_mode();
   //
   // Only process samples if NOT transmitting in CW
-  if (isTransmitting() && (mode==modeCWU || mode==modeCWL)) return;
+  if (isTransmitting() && (txmode==modeCWU || txmode==modeCWL)) return;
 
   // insert the samples
   audiobuffer[audioindex++]=left_audio_sample>>8;

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -1672,6 +1672,12 @@ static void metis_restart() {
   // reset current rx
   current_rx=0;
 
+  //
+  // When restarting, clear the IQ and audio samples
+  //
+  for(i=8;i<OZY_BUFFER_SIZE;i++) {
+    output_buffer[i]=0;
+  }
   // 
   // Some (older) HPSDR apps on the RedPitaya have very small
   // buffers that over-run if too much data is sent
@@ -1684,7 +1690,7 @@ static void metis_restart() {
     ozy_send_buffer();
   }
 
-  sleep(1);
+  usleep(250000L);
 
   // start the data flowing
   metis_start_stop(1);

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -592,8 +592,6 @@ static gpointer receive_thread(gpointer arg) {
 // at various places,
 // we define here the channel number of the receivers, as well as the
 // number of HPSDR receivers to use (up to 5)
-// These are FIXED numbers and depend on the device and whether the code
-// is compiled with or without PURESIGNAL
 // Furthermore, we provide a function that determines the frequency for
 // a given (HPSDR) receiver and for the transmitter.
 //
@@ -601,7 +599,8 @@ static gpointer receive_thread(gpointer arg) {
 
 static int rx_feedback_channel() {
   //
-  // Depending on the device, return channel number of RX feedback receiver
+  // For radios with small FPGAS only supporting 2 RX, use RX1.
+  // Else, use the last RX before the TX feedback channel.
   //
   int ret;
   switch (device) {
@@ -628,7 +627,11 @@ static int rx_feedback_channel() {
 
 static int tx_feedback_channel() {
   //
-  // Depending on the device, return channel number of TX feedback receiver
+  // Radios with small FPGAs use RX2
+  // HERMES uses RX4,
+  // and Angelia and beyond use RX5
+  //
+  // This is hard-coded in the firmware.
   //
   int ret;
   switch (device) {
@@ -654,37 +657,16 @@ static int tx_feedback_channel() {
 }
 
 static int first_receiver_channel() {
-  //
-  // Depending on the device and whether we compiled for PURESIGNAL,
-  // return the channel number of the first receiver
-  //
   return 0;
 }
 
 static int second_receiver_channel() {
-  //
-  // Depending on the device and whether we compiled for PURESIGNAL,
-  // return the channel number of the second receiver
-  //
-  int ret=1;
-#ifdef PURESIGNAL
-  switch (device) {
-    case DEVICE_METIS:
-    case DEVICE_HERMES_LITE:
-      ret=1;
-      break;
-    default:
-      ret=2;
-      break;
-  }
-#endif
-  return ret;
+  return 1;
 }
 
 static long long channel_freq(int chan) {
   //
-  // Depending on PURESIGNAL and DIVERSITY, return
-  // the frequency associated with the current HPSDR
+  // Return the frequency associated with the current HPSDR
   // RX channel (0 <= chan <= 4).
   //
   // This function returns the TX frequency if chan is
@@ -700,28 +682,9 @@ static long long channel_freq(int chan) {
   int vfonum;
   long long freq;
 
+  // RX1 and RX2 are normally used for the first and second receiver.
+  // all other channels are used for PURESIGNAL and get the TX frequency
   switch (chan) {
-#ifdef PURESIGNAL
-    case 0:
-      vfonum=receiver[0]->id;
-      break;
-    case 1:
-      if(device==DEVICE_HERMES_LITE) {
-        vfonum=receiver[1]->id;
-      } else {
-        vfonum=receiver[0]->id;
-      }
-      break;
-    case 2:
-    case 3:
-    case 4:
-      if (diversity_enabled) {
-	vfonum=receiver[0]->id;
-      } else {
-	vfonum=receiver[1]->id;
-      }
-      break;
-#else
     case 0:
       vfonum=receiver[0]->id;
       break;
@@ -732,14 +695,12 @@ static long long channel_freq(int chan) {
 	vfonum=receiver[1]->id;
       }
       break;
-#endif
-    default:   // hook for determining the TX frequency
+    default:   // TX frequency used for all other channels
       vfonum=-1;
       break;
   }
   //
-  // When transmitting with PURESIGNAL, set frequency of PS feedback and TX DAC channels
-  // to the tx frequency
+  // Radios with small FPGAs use RX1/RX2 for feedback while transmitting,
   //
   if (isTransmitting() && transmitter->puresignal && (chan == rx_feedback_channel() || chan == tx_feedback_channel())) {
     vfonum = -1;
@@ -750,19 +711,12 @@ static long long channel_freq(int chan) {
     // We have to adjust by the offset for CTUN mode
     //
     if(active_receiver->id==VFO_A) {
-      if(split) { 
-        vfonum=VFO_B;
-      } else {
-        vfonum=VFO_A;
-      }
+      vfonum = split ? VFO_B : VFO_A;
     } else {
-      if(split) {
-        vfonum=VFO_A;
-      } else {
-        vfonum=VFO_B;
-      }
+      vfonum = split ? VFO_A : VFO_B;
     }
-    freq=vfo[vfonum].frequency-vfo[vfonum].lo+vfo[vfonum].offset;
+    freq=vfo[vfonum].frequency-vfo[vfonum].lo;
+    if (vfo[vfonum].ctun) freq += vfo[vfonum].offset;
     if(transmitter->xit_enabled) {
       freq+=transmitter->xit;
     }
@@ -795,16 +749,18 @@ static long long channel_freq(int chan) {
 
 static int how_many_receivers() {
   //
-  // Depending on how the program is compiled and which board we have,
-  // we use a FIXED number of receivers.
+  // For DIVERSITY, we need at least two RX channels
+  // When PURESIGNAL is active, we need to include the TX DAC channel.
   //
-  int ret = RECEIVERS;
+  int ret = receivers;   	// 1 or 2
+  if (diversity_enabled) ret=2; // need both RX channels, even if there is only one RX
 
 #ifdef PURESIGNAL
     // for PureSignal, the number of receivers needed is hard-coded below.
     // we need at least 2, and up to 5 for Orion2 boards. This is so because
     // the TX DAC is hard-wired to RX4 for HERMES,STEMLAB and to RX5 for ANGELIA
     // and beyond.
+  if (transmitter->puresignal) {
     switch (device) {
       case DEVICE_METIS:
       case DEVICE_HERMES_LITE:
@@ -824,8 +780,9 @@ static int how_many_receivers() {
 	ret=2; // This is the minimum for PURESIGNAL
 	break;
     }
+  }
 #endif
-    return ret;
+  return ret;
 }
 
 static void process_ozy_input_buffer(unsigned char  *buffer) {
@@ -988,10 +945,8 @@ static void process_ozy_input_buffer(unsigned char  *buffer) {
         }
       } // end of loop over the receiver channels
 
-      // TX without PURESIGNAL: receivers are shut down -- do nothing
-
       //
-      // Process mic samples. Take them from buffer or from
+      // Process mic samples. Take them from radio or from
       // "local microphone" ring buffer
       //
       mic_sample  = (short)(buffer[b++]<<8);
@@ -1097,6 +1052,8 @@ void ozy_send_buffer() {
   int i;
   BAND *band;
   int num_hpsdr_receivers=how_many_receivers();
+  int rx1channel = first_receiver_channel();
+  int rx2channel = second_receiver_channel();
 
   output_buffer[SYNC0]=SYNC;
   output_buffer[SYNC1]=SYNC;
@@ -1499,21 +1456,18 @@ void ozy_send_buffer() {
         output_buffer[C0]=0x1C;
         output_buffer[C1]=0x00;
         output_buffer[C2]=0x00;
-#ifdef PURESIGNAL
         // if n_adc == 1, there is only a single ADC, so we can leave everything
         // set to zero
 	if (n_adc  > 1) {
-	    // Angelia, Orion, Orion2 have two ADCs, so we use the ADC settings from the menu
-            output_buffer[C1]|=receiver[0]->adc;			// RX1 bound to ADC of first receiver
-            output_buffer[C1]|=(receiver[1]->adc<<2);			// RX2 actually unsused with PURESIGNAL
-            output_buffer[C1]|=receiver[1]->adc<<4;			// RX3 bound to ADC of second receiver
-            								// RX4 is PS_RX_Feedback and bound to ADC0
-	    								// RX5 is hard-wired to the TX DAC and needs no ADC setting.
+	    // set adc of the two RX associated with the two piHPSDR receivers
+	    if (diversity_enabled) {
+	      // use ADC0 for RX1 and ADC1 for RX2 (fixed setting)
+	      output_buffer[C1]|=0x04;
+	    } else {
+	      output_buffer[C1]|=(receiver[0]->adc<<(2*rx1channel));
+	      output_buffer[C1]|=(receiver[1]->adc<<(2*rx2channel));
+	    }
 	}
-#else
-        output_buffer[C1]|=receiver[0]->adc;				// ADC of first receiver
-        output_buffer[C1]|=(receiver[1]->adc<<2);			// ADC of second receiver
-#endif
         output_buffer[C3]=0x00;
         output_buffer[C3]|=transmitter->attenuation;			// Step attenuator of first ADC, value used when TXing
         output_buffer[C4]=0x00;

--- a/pa_menu.c
+++ b/pa_menu.c
@@ -55,9 +55,8 @@ static gboolean delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_d
 static void pa_value_changed_cb(GtkWidget *widget, gpointer data) {
   BAND *band=(BAND *)data;
   band->pa_calibration=gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget));
-  int v=VFO_A;
-  if(split) v=VFO_B;
-  int b=vfo[v].band;
+  int txvfo=get_tx_vfo();
+  int b=vfo[txvfo].band;
   BAND *current=band_get_band(b);
   if(band==current) {
     calcDriveLevel();

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -219,14 +219,21 @@ static int info_thread(gpointer arg) {
       old5_2=info[5];
       switch(state) {
         case 0:
-          if(newcal && (info[4]>181 || (info[4]<=128 && transmitter->attenuation>0))) {
-	    if (info[4] > 0) {
+	  //
+	  // A value of 175 means 1.2 dB too strong
+	  // A value of 132 means 1.2 dB too weak
+	  //
+          if(newcal && ((info[4]>175 && transmitter->attenuation < 31) || (info[4]<=132 && transmitter->attenuation>0))) {
+            if (info[4] > 256) {
+	      // If signal is very strong, start with large attenuation and then step up
+	      ddb = 100.0;  // this makes the attenuation 31 dB in the next step
+            } else if (info[4] > 0) {
               ddb= 20.0 * log10((double)info[4]/152.293);
 	    } else {
 	      // This happens when the "Drive" slider is moved to zero
-	      ddb= -100.0;
+	      ddb= -100.0;  // this makes the attenuation zero in the next step
 	    }
-            new_att=transmitter->attenuation + (int)ddb;
+            new_att=transmitter->attenuation + (int)lround(ddb);
 	    // keep new value of attenuation in allowed range
 	    if (new_att <  0) new_att= 0;
 	    if (new_att > 31) new_att=31;

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -28,7 +28,6 @@
 #include "toolbar.h"
 #include "transmitter.h"
 #include "new_protocol.h"
-#include "old_protocol.h"
 #include "vfo.h"
 #include "ext.h"
 
@@ -41,18 +40,18 @@ static GtkWidget *set_pk;
 static GtkWidget *tx_att;
 
 /*
- * PureSignal 2.0 default parameters and declarations
+ * PureSignal 2.0 parameters and declarations
  */
 
-static double ampdelay  = 20e-9;   // 20 nsec
+static double ampdelay  = 150e-9;  // 150 nsec
 static int    ints      = 16;
-static int    spi       = 256;
-static int    stbl      = 0;
-static int    map       = 1;
-static int    pin       = 1;
-static double ptol      = 0.8;
-static double moxdelay  = 0.1;
-static double loopdelay = 0.0;
+static int    spi       = 256;     // ints=16/spi=256 corresponds to "TINT=0.5 dB"
+static int    stbl      = 0;	   // "Stbl" un-checked
+static int    map       = 1;       // "Map"  checked
+static int    pin       = 1;	   // "Pin"  checked
+static double ptol      = 0.8;     // "Relax Tolerance" un-checked
+static double moxdelay  = 0.2;     // "MOX Wait" 0.2 sec
+static double loopdelay = 0.0;     // "CAL Wait" 0.0 sec
 
 //
 // The following declarations are missing in wdsp.h
@@ -287,17 +286,7 @@ static void ps_ant_cb(GtkWidget *widget, gpointer data) {
 }
 
 static void enable_cb(GtkWidget *widget, gpointer data) {
-  //
-  // Enabling/Disabling changes the number of required
-  // of HPSR receivers so we restart the original protocol
-  //
-  if (protocol == ORIGINAL_PROTOCOL) {
-    old_protocol_stop();
-  }
   g_idle_add(ext_tx_set_ps,GINT_TO_POINTER(gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget))));
-  if (protocol == ORIGINAL_PROTOCOL) {
-    old_protocol_run();
-  }
 }
 
 static void auto_cb(GtkWidget *widget, gpointer data) {
@@ -570,14 +559,6 @@ void ps_menu(GtkWidget *parent) {
 
   gtk_container_add(GTK_CONTAINER(content),grid);
   sub_menu=dialog;
-
-// DL1YCF: This is not the default setting,
-// but in my experience in behaves better in difficult situations.
-// This is commented out because it is not recommended by the
-// WDSP manual.
-//  ints=8;
-//  spi=512;
-//  ampdelay=100e-9;
 
   SetPSIntsAndSpi(transmitter->id, ints, spi);
   SetPSStabilize(transmitter->id, stbl);

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -28,6 +28,7 @@
 #include "toolbar.h"
 #include "transmitter.h"
 #include "new_protocol.h"
+#include "old_protocol.h"
 #include "vfo.h"
 #include "ext.h"
 
@@ -286,7 +287,17 @@ static void ps_ant_cb(GtkWidget *widget, gpointer data) {
 }
 
 static void enable_cb(GtkWidget *widget, gpointer data) {
+  //
+  // Enabling/Disabling changes the number of required
+  // of HPSR receivers so we restart the original protocol
+  //
+  if (protocol == ORIGINAL_PROTOCOL) {
+    old_protocol_stop();
+  }
   g_idle_add(ext_tx_set_ps,GINT_TO_POINTER(gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget))));
+  if (protocol == ORIGINAL_PROTOCOL) {
+    old_protocol_run();
+  }
 }
 
 static void auto_cb(GtkWidget *widget, gpointer data) {

--- a/radio.c
+++ b/radio.c
@@ -1070,6 +1070,13 @@ void radio_change_receivers(int r) {
   // number of receivers has not changed.
   if (receivers == r) return;
   fprintf(stderr,"radio_change_receivers: from %d to %d\n",receivers,r);
+  //
+  // When changing the number of receivers, restart the
+  // old protocol
+  //
+  if (protocol == ORIGINAL_PROTOCOL) {
+    old_protocol_stop();
+  }
   switch(r) {
     case 1:
 	set_displaying(receiver[1],0);
@@ -1086,6 +1093,9 @@ void radio_change_receivers(int r) {
   active_receiver=receiver[0];
   if(protocol==NEW_PROTOCOL) {
     schedule_high_priority();
+  }
+  if (protocol == ORIGINAL_PROTOCOL) {
+    old_protocol_run();
   }
 }
 

--- a/radio.c
+++ b/radio.c
@@ -1350,11 +1350,8 @@ void setTune(int state) {
         }
       }
 
-      int mode=vfo[VFO_A].mode;
-      if(split) {
-        mode=vfo[VFO_B].mode;
-      }
-      pre_tune_mode=mode;
+      int txmode=get_tx_mode();
+      pre_tune_mode=txmode;
       pre_tune_cw_internal=cw_keyer_internal;
 
       //
@@ -1362,7 +1359,7 @@ void setTune(int state) {
       // in LSB/DIGL,     tune 1000 Hz below carrier
       // all other (CW, AM, FM): tune on carrier freq.
       //
-      switch(mode) {
+      switch(txmode) {
         case modeLSB:
         case modeDIGL:
           SetTXAPostGenToneFreq(transmitter->id,-(double)1000.0);
@@ -1381,7 +1378,7 @@ void setTune(int state) {
       SetTXAPostGenMode(transmitter->id,0);
       SetTXAPostGenRun(transmitter->id,1);
 
-      switch(mode) {
+      switch(txmode) {
         case modeCWL:
           cw_keyer_internal=0;
           tx_set_mode(transmitter,modeLSB);
@@ -1471,8 +1468,7 @@ double getDrive() {
 
 static int calcLevel(double d) {
   int level=0;
-  int v=VFO_A;
-  if(split) v=VFO_B;
+  int v=get_tx_vfo();
 
   BAND *band=band_get_band(vfo[v].band);
   double target_dbm = 10.0 * log10(d * 1000.0);

--- a/radio_menu.c
+++ b/radio_menu.c
@@ -50,6 +50,10 @@ static GtkWidget *tx_gains[2];
 static GtkWidget *sat_b;
 static GtkWidget *rsat_b;
 
+static GtkWidget *receivers_1;
+static GtkWidget *receivers_2;
+static GtkWidget *duplex_b;
+
 static void cleanup() {
   if(dialog!=NULL) {
     gtk_widget_destroy(dialog);
@@ -214,6 +218,10 @@ void setDuplex() {
 }
 
 static void duplex_cb(GtkWidget *widget, gpointer data) {
+  if (isTransmitting()) {
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (duplex_b), duplex);
+    return;
+  }
   duplex=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
   setDuplex();
 }
@@ -319,6 +327,15 @@ static void sample_rate_cb(GtkToggleButton *widget, gpointer data) {
 }
 
 static void receivers_cb(GtkToggleButton *widget, gpointer data) {
+  //
+  // reconfigure_radio requires that the RX panels are active
+  // (segfault otherwise), therefore ignore this while TXing
+  //
+  if (isTransmitting()) {
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (receivers_1), receivers==1);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (receivers_2), receivers==2);
+    return;
+  }
   if(gtk_toggle_button_get_active(widget)) {
     radio_change_receivers(GPOINTER_TO_INT(data));
   }
@@ -403,14 +420,14 @@ void radio_menu(GtkWidget *parent) {
 
   row++;
   
-  GtkWidget *receivers_1=gtk_radio_button_new_with_label(NULL,"1");
+             receivers_1=gtk_radio_button_new_with_label(NULL,"1");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (receivers_1), receivers==1);
   gtk_grid_attach(GTK_GRID(grid),receivers_1,col,row,1,1);
   g_signal_connect(receivers_1,"toggled",G_CALLBACK(receivers_cb),(gpointer *)1);
 
   row++;
 
-  GtkWidget *receivers_2=gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(receivers_1),"2");
+             receivers_2=gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(receivers_1),"2");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (receivers_2), receivers==2);
   gtk_grid_attach(GTK_GRID(grid),receivers_2,col,row,1,1);
   g_signal_connect(receivers_2,"toggled",G_CALLBACK(receivers_cb),(gpointer *)2);
@@ -684,7 +701,7 @@ void radio_menu(GtkWidget *parent) {
 
   col++;
 
-  GtkWidget *duplex_b=gtk_check_button_new_with_label("Duplex");
+             duplex_b=gtk_check_button_new_with_label("Duplex");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (duplex_b), duplex);
   gtk_grid_attach(GTK_GRID(grid),duplex_b,col,row,1,1);
   g_signal_connect(duplex_b,"toggled",G_CALLBACK(duplex_cb),NULL);

--- a/radio_menu.c
+++ b/radio_menu.c
@@ -40,6 +40,7 @@
 #endif
 #include "gpio.h"
 #include "vfo.h"
+#include "ext.h"
 
 static GtkWidget *parent_window=NULL;
 static GtkWidget *menu_b=NULL;
@@ -196,12 +197,12 @@ static void iqswap_cb(GtkWidget *widget, gpointer data) {
 }
 
 static void split_cb(GtkWidget *widget, gpointer data) {
-  split=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
-  vfo_update();
+  int new=gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
+  if (new != split) g_idle_add(ext_split_toggle, NULL);
 }
 
 //
-// call-able from outside, e.g. toolbar or MIDI
+// call-able from outside, e.g. toolbar or MIDI, through g_idle_add
 //
 void setDuplex() {
   if(duplex) {
@@ -214,7 +215,7 @@ void setDuplex() {
     gtk_widget_destroy(transmitter->dialog);
     reconfigure_transmitter(transmitter,display_width,rx_height*receivers);
   }
-  vfo_update();
+  g_idle_add(ext_vfo_update, NULL);
 }
 
 static void duplex_cb(GtkWidget *widget, gpointer data) {
@@ -228,7 +229,7 @@ static void duplex_cb(GtkWidget *widget, gpointer data) {
 
 static void sat_cb(GtkWidget *widget, gpointer data) {
   sat_mode=gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-  vfo_update();
+  g_idle_add(ext_vfo_update, NULL);
 }
 
 static void load_filters(void) {

--- a/receiver.c
+++ b/receiver.c
@@ -889,8 +889,12 @@ fprintf(stderr,"create_pure_signal_receiver: id=%d buffer_size=%d\n",id,buffer_s
     init_analyzer(rx);
   }
 
-  SetDisplayDetectorMode(rx->id, 0, display_detector_mode);
-  SetDisplayAverageMode(rx->id, 0,  display_average_mode);
+  //
+  // This cannot be changed for the PS feedback receiver,
+  // use peak mode
+  //
+  SetDisplayDetectorMode(rx->id, 0, DETECTOR_MODE_PEAK);
+  SetDisplayAverageMode(rx->id, 0,  AVERAGE_MODE_NONE);
 
   return rx;
 }

--- a/soapy_protocol.c
+++ b/soapy_protocol.c
@@ -369,10 +369,7 @@ void soapy_protocol_set_tx_frequency(TRANSMITTER *tx) {
   int rc;
   double f;
 
-  v=active_receiver->id;
-  if(split) {
-    v=active_receiver->id==0?1:0;
-  }
+  v=get_tx_vfo();
   if(soapy_device!=NULL) {
     //f=(double)(vfo[v].frequency+vfo[v].ctun_frequency-vfo[v].lo_tx);
     if(vfo[v].ctun) {

--- a/toolbar.c
+++ b/toolbar.c
@@ -276,15 +276,7 @@ static void aswapb_cb (GtkWidget *widget, gpointer data) {
 }
 
 static void split_cb (GtkWidget *widget, gpointer data) {
-  if(can_transmit) {
-    split=split==1?0:1;
-    if(split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    } else {
-      tx_set_mode(transmitter,vfo[VFO_A].mode);
-    }
-    g_idle_add(ext_vfo_update,NULL);
-  }
+  g_idle_add(ext_split_toggle, NULL);
 }
 
 static void duplex_cb (GtkWidget *widget, gpointer data) {

--- a/transmitter.c
+++ b/transmitter.c
@@ -575,6 +575,13 @@ static void init_analyzer(TRANSMITTER *tx) {
             span_max_freq, //frequency at last pixel value
             max_w //max samples to hold in input ring buffers
     );
+   //
+   // This cannot be changed for the TX panel,
+   // use peak mode
+   //
+   SetDisplayDetectorMode(tx->id, 0, DETECTOR_MODE_PEAK);
+   SetDisplayAverageMode(tx->id, 0,  AVERAGE_MODE_NONE);
+
 
 }
 

--- a/transmitter.c
+++ b/transmitter.c
@@ -1289,6 +1289,10 @@ void tx_set_displaying(TRANSMITTER *tx,int state) {
 
 void tx_set_ps(TRANSMITTER *tx,int state) {
 #ifdef PURESIGNAL
+  if (protocol == ORIGINAL_PROTOCOL) {
+    old_protocol_stop();
+    usleep(100000);
+  }
   if(state) {
     tx->puresignal=1;
     SetPSControl(tx->id, 0, 0, 1, 0);
@@ -1301,6 +1305,9 @@ void tx_set_ps(TRANSMITTER *tx,int state) {
   if (protocol == NEW_PROTOCOL) {
     schedule_high_priority();
     schedule_receive_specific();
+  }
+  if (protocol == ORIGINAL_PROTOCOL) {
+    old_protocol_run();
   }
   g_idle_add(ext_vfo_update,NULL);
 #endif

--- a/tx_panadapter.c
+++ b/tx_panadapter.c
@@ -262,9 +262,9 @@ void tx_panadapter_update(TRANSMITTER *tx) {
     }
   }
 
+  cairo_text_extents_t extents;
 #ifdef TX_FREQ_MARKERS
   long long f;
-  cairo_text_extents_t extents;
   long long divisor=50000;
   for(i=0;i<display_width;i++) {
     f = frequency - half + (long) (hz_per_pixel * i);

--- a/tx_panadapter.c
+++ b/tx_panadapter.c
@@ -186,11 +186,9 @@ void tx_panadapter_update(TRANSMITTER *tx) {
   int display_width=gtk_widget_get_allocated_width (tx->panadapter);
   int display_height=gtk_widget_get_allocated_height (tx->panadapter);
 
-  // id = VFO which contains the TX frequency
-  int id = active_receiver->id;
-  if (split) {
-    id = 1-id;
-  }
+  int txvfo = get_tx_vfo();
+  int txmode = get_tx_mode();
+
   samples=tx->pixel_samples;
 
   hz_per_pixel=(double)tx->iq_output_rate/(double)tx->pixels;
@@ -203,7 +201,7 @@ void tx_panadapter_update(TRANSMITTER *tx) {
 
   
   // filter
-  if (vfo[id].mode != modeCWU && vfo[id].mode != modeCWL) {
+  if (txmode != modeCWU && txmode != modeCWL) {
     cairo_set_source_rgb (cr, 0.25, 0.25, 0.25);
     filter_left=(double)display_width/2.0+((double)tx->filter_low/hz_per_pixel);
     filter_right=(double)display_width/2.0+((double)tx->filter_high/hz_per_pixel);
@@ -246,17 +244,17 @@ void tx_panadapter_update(TRANSMITTER *tx) {
   //long long half=24000LL; //(long long)(tx->output_rate/2);
   long long half=6000LL; //(long long)(tx->output_rate/2);
   long long frequency;
-  if(vfo[id].ctun) {
-    frequency=vfo[id].ctun_frequency-vfo[id].lo_tx;
+  if(vfo[txvfo].ctun) {
+    frequency=vfo[txvfo].ctun_frequency-vfo[txvfo].lo_tx;
   } else {
-    frequency=vfo[id].frequency-vfo[id].lo_tx;
+    frequency=vfo[txvfo].frequency-vfo[txvfo].lo_tx;
   }
   double vfofreq=(double)display_width * 0.5;
   if (!cw_is_on_vfo_freq) {
-    if(vfo[id].mode==modeCWU) {
+    if(txmode==modeCWU) {
       frequency+=(long long)cw_keyer_sidetone_frequency;
       vfofreq -=  (double) cw_keyer_sidetone_frequency/hz_per_pixel;
-    } else if(vfo[id].mode==modeCWL) {
+    } else if(txmode==modeCWL) {
       frequency-=(long long)cw_keyer_sidetone_frequency;
       vfofreq +=  (double) cw_keyer_sidetone_frequency/hz_per_pixel;
     }
@@ -295,7 +293,7 @@ void tx_panadapter_update(TRANSMITTER *tx) {
   // band edges
   long long min_display=frequency-half;
   long long max_display=frequency+half;
-  int b=vfo[id].band;
+  int b=vfo[txvfo].band;
   BAND *band=band_get_band(b);
   if(band->frequencyMin!=0LL) {
     cairo_set_source_rgb (cr, 1.0, 0.0, 0.0);

--- a/vfo.c
+++ b/vfo.c
@@ -1049,39 +1049,6 @@ void vfo_update() {
         cairo_set_source_rgb(cr, 1.0, 1.0, 0.0);
         cairo_show_text(cr, temp_text);
 
-       
-        long long txfreq;
-        int txlow, txhigh;
-
-        if (can_transmit) {
-          txfreq = (txvfo == 0) ? af : bf;
-          if (transmitter->xit_enabled) txfreq += transmitter->xit;
-	  //
-	  // In CW modes, the signal is generated explicitly (without WDSP),
-	  // so we can assume a zero-width filter. Note that the CW signal
-	  // can be on the VFO frequency or offset by the side tone freq.
-	  //
-          switch (transmitter->mode) {
-	    case modeCWU:
-              txlow = txhigh = cw_is_on_vfo_freq ? 0 : cw_keyer_sidetone_frequency;
-	      break;
-	    case modeCWL:
-              txlow = txhigh = cw_is_on_vfo_freq ? 0 : -cw_keyer_sidetone_frequency;
-	      break;
-	    default:
-              txlow =transmitter->filter_low;
-              txhigh=transmitter->filter_high;
-	    break;
-	  }
-	} else {
-	  //
-	  // If there is no transmitter, use VFO frequency of active receiver
-	  //
-	  txfreq = (id == 0) ? af : bf;
-	  txlow = 0;
-	  txhigh =0;
-	}
-        getFrequencyInfo(txfreq, txlow, txhigh);
 /*
         cairo_move_to(cr, (my_width/4)*3, 50);
         cairo_show_text(cr, getFrequencyInfo(af));

--- a/vfo.c
+++ b/vfo.c
@@ -318,11 +318,7 @@ void vfo_band_changed(int b) {
   }
 
   if(can_transmit) {
-    if(split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    } else {
-      tx_set_mode(transmitter,vfo[VFO_A].mode);
-    }
+    tx_set_mode(transmitter,get_tx_mode());
     //
     // If the band has changed, it is necessary to re-calculate
     // the drive level. Furthermore, possibly the "PA disable"
@@ -367,11 +363,7 @@ void vfo_bandstack_changed(int b) {
   }
 
   if(can_transmit) {
-    if(split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    } else {
-      tx_set_mode(transmitter,vfo[VFO_A].mode);
-    }
+      tx_set_mode(transmitter,get_tx_mode());
   }
   //
   // I do not think the band can change within this function.
@@ -414,11 +406,7 @@ void vfo_mode_changed(int m) {
       break;
   }
   if(can_transmit) {
-    if(split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    } else {
-      tx_set_mode(transmitter,vfo[VFO_A].mode);
-    }
+      tx_set_mode(transmitter,get_tx_mode());
   }
   //
   // changing modes may change BFO frequency
@@ -467,9 +455,7 @@ void vfo_a_to_b() {
     receiver_vfo_changed(receiver[1]);
   }
   if(can_transmit) {
-    if(split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    }
+    tx_set_mode(transmitter,get_tx_mode());
   }
   g_idle_add(ext_vfo_update,NULL);
 }
@@ -486,9 +472,7 @@ void vfo_b_to_a() {
   vfo[VFO_A].rit=vfo[VFO_B].rit;
   receiver_vfo_changed(receiver[0]);
   if(can_transmit) {
-    if(!split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    }
+    tx_set_mode(transmitter,get_tx_mode());
   }
   g_idle_add(ext_vfo_update,NULL);
 }
@@ -539,11 +523,7 @@ void vfo_a_swap_b() {
     receiver_vfo_changed(receiver[1]);
   }
   if(can_transmit) {
-    if(split) {
-      tx_set_mode(transmitter,vfo[VFO_B].mode);
-    } else {
-      tx_set_mode(transmitter,vfo[VFO_A].mode);
-    }
+    tx_set_mode(transmitter,get_tx_mode());
   }
   g_idle_add(ext_vfo_update,NULL);
 }
@@ -832,6 +812,8 @@ static gboolean vfo_draw_cb (GtkWidget *widget,
 void vfo_update() {
     
     int id=active_receiver->id;
+    int txvfo=get_tx_vfo();
+
     FILTER* band_filters=filters[vfo[id].mode];
     FILTER* band_filter=&band_filters[vfo[id].filter];
     if(vfo_surface) {
@@ -885,32 +867,19 @@ void vfo_update() {
 	// If it is out-of-band, we display "Out of band" in red.
         // Frequencies we are not transmitting on are displayed in green
 	// (dimmed if the freq. does not belong to the active receiver).
-        // Depending on which receiver is the active one, and if we use split,
-        // the following frequencies are used for transmitting (see old_protocol.c):
-	// id == 0, split == 0 : TX freq = VFO_A
-	// id == 0, split == 1 : TX freq = VFO_B
-	// id == 1, split == 0 : TX freq = VFO_B
-	// id == 1, split == 1 : TX freq = VFO_A
 
+        // Frequencies of VFO A and B
 
-        long long af;
-        if(isTransmitting() && !split) {
-          if(vfo[0].ctun) {
-            af=(double)(vfo[0].ctun_frequency-vfo[0].lo_tx);
-          } else {
-            af=(double)(vfo[0].frequency-vfo[0].lo_tx);
-          }
-        } else {
-          if(vfo[0].ctun) {
-            af=(double)(vfo[0].ctun_frequency);
-          } else {
-            af=(double)(vfo[0].frequency);
-          }
-        }
+        long long af = vfo[0].ctun ? vfo[0].ctun_frequency : vfo[0].frequency;
+        long long bf = vfo[1].ctun ? vfo[1].ctun_frequency : vfo[1].frequency;
+
+        int oob=0;
+        if (can_transmit) oob=transmitter->out_of_band;
 
         sprintf(temp_text,"VFO A: %0lld.%06lld",af/(long long)1000000,af%(long long)1000000);
-        if(isTransmitting() && ((id  == 0 && !split) || (id == 1 && split))) {
-	    if (transmitter->out_of_band) sprintf(temp_text,"VFO A: Out of band");
+
+        if(txvfo == 0 && (isTransmitting() || oob)) {
+            if (oob) sprintf(temp_text,"VFO A: Out of band");
             cairo_set_source_rgb(cr, 1.0, 0.0, 0.0);
         } else {
             if(id==0) {
@@ -923,24 +892,9 @@ void vfo_update() {
         cairo_set_font_size(cr, 22); 
         cairo_show_text(cr, temp_text);
 
-
-        long long bf;
-        if(isTransmitting() && split) {
-          if(vfo[1].ctun) {
-            bf=(double)(vfo[1].ctun_frequency-vfo[1].lo_tx);
-          } else {
-            bf=(double)(vfo[1].frequency-vfo[1].lo_tx);
-          }
-        } else {
-          if(vfo[1].ctun) {
-            bf=(double)(vfo[1].ctun_frequency);
-          } else {
-            bf=(double)(vfo[1].frequency);
-          }
-        }
         sprintf(temp_text,"VFO B: %0lld.%06lld",bf/(long long)1000000,bf%(long long)1000000);
-        if(isTransmitting() && ((id == 0 && split) || (id == 1 && !split))) {
-	    if (transmitter->out_of_band) sprintf(temp_text,"VFO B: Out of band");
+        if(txvfo == 1 && (isTransmitting() || oob)) {
+            if (oob) sprintf(temp_text,"VFO B: Out of band");
             cairo_set_source_rgb(cr, 1.0, 0.0, 0.0);
         } else {
             if(id==1) {
@@ -1095,35 +1049,37 @@ void vfo_update() {
         cairo_set_source_rgb(cr, 1.0, 1.0, 0.0);
         cairo_show_text(cr, temp_text);
 
-        //
-        // af: Frequency of VFO_A, bf: Frequency of VFO_B, without xit/rit etc.
-        //
+       
         long long txfreq;
         int txlow, txhigh;
 
-        if ((id == 0 && ! split) || (id == 1 && split)) {
-	  // txfreq derived from VFO A
-          txfreq=af;
-        } else {
-          txfreq=bf;
-        }
-        if (transmitter->xit_enabled) txfreq += transmitter->xit;
-	//
-	// In CW modes, the signal is generated explicitly (without WDSP),
-	// so we can assume a zero-width filter. Note that the CW signal
-	// can be on the VFO frequency or offset by the side tone freq.
-	//
-        switch (transmitter->mode) {
-	  case modeCWU:
-            txlow = txhigh = cw_is_on_vfo_freq ? 0 : cw_keyer_sidetone_frequency;
+        if (can_transmit) {
+          txfreq = (txvfo == 0) ? af : bf;
+          if (transmitter->xit_enabled) txfreq += transmitter->xit;
+	  //
+	  // In CW modes, the signal is generated explicitly (without WDSP),
+	  // so we can assume a zero-width filter. Note that the CW signal
+	  // can be on the VFO frequency or offset by the side tone freq.
+	  //
+          switch (transmitter->mode) {
+	    case modeCWU:
+              txlow = txhigh = cw_is_on_vfo_freq ? 0 : cw_keyer_sidetone_frequency;
+	      break;
+	    case modeCWL:
+              txlow = txhigh = cw_is_on_vfo_freq ? 0 : -cw_keyer_sidetone_frequency;
+	      break;
+	    default:
+              txlow =transmitter->filter_low;
+              txhigh=transmitter->filter_high;
 	    break;
-	  case modeCWL:
-            txlow = txhigh = cw_is_on_vfo_freq ? 0 : -cw_keyer_sidetone_frequency;
-	    break;
-	  default:
-            txlow =transmitter->filter_low;
-            txhigh=transmitter->filter_high;
-	    break;
+	  }
+	} else {
+	  //
+	  // If there is no transmitter, use VFO frequency of active receiver
+	  //
+	  txfreq = (id == 0) ? af : bf;
+	  txlow = 0;
+	  txhigh =0;
 	}
         getFrequencyInfo(txfreq, txlow, txhigh);
 /*
@@ -1253,4 +1209,36 @@ fprintf(stderr,"vfo_init: width=%d height=%d\n", width, height);
                      | GDK_SCROLL_MASK);
 
   return vfo_panel;
+}
+
+//
+// Some utility functions to get characteristics of the current
+// transmitter. These functions can be used even if there is no
+// transmitter (transmitter->mode may segfault).
+//
+
+int get_tx_vfo() {
+  int txvfo=active_receiver->id;
+  if (split) txvfo = 1 - txvfo;
+  return txvfo;
+}
+
+int get_tx_mode() {
+  int txvfo=active_receiver->id;
+  if (split) txvfo = 1 - txvfo;
+  if (can_transmit) {
+    return vfo[txvfo].mode;
+  } else {
+    return modeUSB;
+  }
+}
+
+long long get_tx_freq() {
+  int txvfo=active_receiver->id;
+  if (split) txvfo = 1 - txvfo;
+  if (vfo[txvfo].ctun) {
+    return  vfo[txvfo].ctun_frequency;
+  } else {
+    return vfo[txvfo].frequency;
+  }
 }

--- a/vfo.c
+++ b/vfo.c
@@ -296,6 +296,7 @@ void vfo_band_changed(int b) {
 
   // turn off ctun
   vfo[id].ctun=0;
+  vfo[id].offset=0;
 
   switch(id) {
     case 0:

--- a/vfo.h
+++ b/vfo.h
@@ -85,5 +85,9 @@ extern void vfo_a_to_b();
 extern void vfo_b_to_a();
 extern void vfo_a_swap_b();
 
+extern int get_tx_vfo();
+extern int get_tx_mode();
+extern long long get_tx_freq();
+
 extern void vfo_xvtr_changed();
 #endif


### PR DESCRIPTION
Changelog:

- updated HermesLite V1/V2 discrimination
- OldProtocol: restart when changing the number of needed receivers, or
  enabling/disabling PURESIGNAL,
  and only using as many as we CURRENTLY need
- let the CW key not induce an RX/TX transition if not cw_breakin or no CW mode
- do not change duples and #receivers while transmitting
- re-organized RX channels in old protocol
- changed PURESIGNAL 2.0 default parameter AmpDelay
- choose "peak mode" for TX and RX feedback panadapter spectrum
- restored "Out of Band" messages in VFO
- re-constructed determination of TX mode, frequency, vfo.
- new implementation of canTransmit()
- make PS auto-att a little bit more precise
