### PR TITLE
use of keyboard ; up (u) and down (d) VFO

### DIFF
--- a/main.c
+++ b/main.c
@@ -109,20 +109,34 @@ static void* wisdom_thread(void *arg) {
 //
 gboolean keypress_cb(GtkWidget *widget, GdkEventKey *event, gpointer data) {
 
-  if (event->keyval == GDK_KEY_space && radio != NULL) {
-    if(getTune()==1) {
-      setTune(0);
-    }
-    if(getMox()==1) {
-      setMox(0);
-    } else if(canTransmit() || tx_out_of_band) {
-      setMox(1);
-    } else {
-      transmitter_set_out_of_band(transmitter);
-    }
-    g_idle_add(ext_vfo_update,NULL);
-    return TRUE;
+   if (radio != NULL) {
+	  if (event->keyval == GDK_KEY_space) {
+		  
+		  fprintf(stderr, "space");
+		  
+		if(getTune()==1) {
+		  setTune(0);
+		}
+		if(getMox()==1) {
+		  setMox(0);
+		} else if(canTransmit() || tx_out_of_band) {
+		  setMox(1);
+		} else {
+		  transmitter_set_out_of_band(transmitter);
+		}
+		g_idle_add(ext_vfo_update,NULL);
+		return TRUE;
+	  }
+	  if (event->keyval == GDK_KEY_d ) {
+		vfo_move(step,TRUE);
+		return TRUE;
+	  }
+	  if (event->keyval == GDK_KEY_u ) {
+		 vfo_move(-step,TRUE);
+		 return TRUE;
+	  }
   }
+  
   return FALSE;
 }
 

--- a/radio.c
+++ b/radio.c
@@ -1013,11 +1013,9 @@ void start_radio() {
 #endif
   
 #ifdef GPIO
-  if(controller!=NO_CONTROLLER) {
     if(gpio_init()<0) {
       g_print("GPIO failed to initialize\n");
     }
-  }
 #endif
 #ifdef LOCALCW
   // init local keyer if enabled


### PR DESCRIPTION
John,

I did bought a usb volume knob. 

Based on the following link:
https://andrewmemory.wordpress.com/2019/12/16/mapping-a-usb-volume-knob-into-a-keyboard-on-linux-for-sdr/

i redirected the events of the knob to key events; using u and d i can control the vfo frequency of pihpsdr.

For the other controls iam using the touch screen.

Please merge.

73 Johan
PA3GSB
