### PR TITLE
more fixes:

### DIFF
--- a/hpsdrsim.c
+++ b/hpsdrsim.c
@@ -1059,7 +1059,7 @@ void process_ep2(uint8_t *frame)
 	     // to an RX gain of -12 to +48 dB. However, we set here that
              // a value of +16 (that is, 28 on the 0-60 scale) corresponds to
              // "zero attenuation"
-	     chk_data(40 -(frame[4] & 0x3F) , rx_att[0], "RX1 HL ATT/GAIN");
+	     chk_data(37 -(frame[4] & 0x3F) , rx_att[0], "RX1 HL ATT/GAIN");
            } else {
              chk_data((frame[4] & 0x1F) >> 0, rx_att[0], "RX1 ATT");
              chk_data((frame[4] & 0x20) >> 5, rx1_attE, "RX1 ATT enable");

--- a/hpsdrsim.c
+++ b/hpsdrsim.c
@@ -1056,17 +1056,10 @@ void process_ep2(uint8_t *frame)
 	     // Some firmware/emulators use bit6 to indicate a 6-bit format
 	     // for a combined attenuator/preamplifier with the AD9866 chip.
 	     // The value is between 0 and 60 and formally correspondes to
-	     // to an RX gain of -12 to +48 dB. However the front-end hardware
-	     // determines which is the correct "zero level", that is, the gain
-	     // which corresponds to full-amplitude IQ samples for a 0 dBm input.
-	     // Experimentally, we set this "zero level" to +13 dB that (that is,
-	     // a RxGain value of 25). So the "attenuation" is (25 -G) where G
-	     // is the RXgain value.
-	     // NOTE: according to the AD9866 data sheet, this "calibration value"
-	     //       should be 22 instead of 25, while a value of 31 is used
-	     //       by the HermesLite firmware  when bit6 is not set.
-	     //
-	     chk_data(25 -(frame[4] & 0x3F) , rx_att[0], "RX1 HL ATT/GAIN");
+	     // to an RX gain of -12 to +48 dB. However, we set here that
+             // a value of +16 (that is, 28 on the 0-60 scale) corresponds to
+             // "zero attenuation"
+	     chk_data(40 -(frame[4] & 0x3F) , rx_att[0], "RX1 HL ATT/GAIN");
            } else {
              chk_data((frame[4] & 0x1F) >> 0, rx_att[0], "RX1 ATT");
              chk_data((frame[4] & 0x20) >> 5, rx1_attE, "RX1 ATT enable");

--- a/meter.c
+++ b/meter.c
@@ -439,7 +439,7 @@ if(analog_meter) {
       max_count++;
 
       //angle=(max_level/2.0)+offset;
-      angle=(max_level*10.0*interval)+offset;
+      angle=(max_level*10.0/(double)interval)+offset;
       radians=angle*M_PI/180.0;
       cairo_arc(cr, cx, cy, radius+8, radians, radians);
       cairo_line_to(cr, cx, cy);

--- a/meter.c
+++ b/meter.c
@@ -200,7 +200,7 @@ if(analog_meter) {
     case SMETER:
       {
       if(have_rx_gain) {
-        level=value+40.0-(adc_attenuation[rx->adc]+12.0);
+        level=value+rx_gain_calibration-adc_attenuation[rx->adc];
       } else {
         level=value+(double)adc_attenuation[rx->adc];
       }
@@ -570,7 +570,7 @@ if(analog_meter) {
       text_location=10;
       offset=5.0;
       if(have_rx_gain) {
-        level=value+40.0-(adc_attenuation[rx->adc]+12.0);
+        level=value+rx_gain_calibration-adc_attenuation[rx->adc];
       } else {
         level=value+(double)adc_attenuation[rx->adc];
       }

--- a/meter_menu.c
+++ b/meter_menu.c
@@ -139,6 +139,7 @@ void meter_menu (GtkWidget *parent) {
   row++;
   col=0;
 
+  col++;
   GtkWidget *alc_gain=gtk_radio_button_new_with_label_from_widget(GTK_RADIO_BUTTON(alc_peak),"ALC Gain");
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (alc_gain), alc==TXA_ALC_GAIN);
   gtk_widget_show(alc_gain);

--- a/midi3.c
+++ b/midi3.c
@@ -103,17 +103,31 @@ void DoTheMidi(enum MIDIaction action, enum MIDItype type, int val) {
 		}
 		break;
 	      case MIDI_WHEEL:
-		  new=adc_attenuation[active_receiver->adc] + val;
-		  if (new > 31) new=31;
-		  if (new < 0 ) new=0;
-		  dp=malloc(sizeof(double));
-		  *dp=new;
-		  g_idle_add(ext_set_attenuation_value,(gpointer) dp);
-		  break;
-	      case MIDI_KNOB:
-		new=(31*val)/100;
+		new=adc_attenuation[active_receiver->adc] + val;
 		dp=malloc(sizeof(double));
-		*dp=new;
+		*dp=(double) new;
+                if(have_rx_gain) {
+                  if(*dp<-12.0) {
+                    *dp=-12.0;
+                  } else if(*dp>48.0) {
+                    *dp=48.0;
+                  }
+                } else {
+                  if(*dp<0.0) {
+                    *dp=0.0;
+                  } else if (*dp>31.0) {
+                    *dp=31.0;
+                  }
+                }
+		g_idle_add(ext_set_attenuation_value,(gpointer) dp);
+		break;
+	      case MIDI_KNOB:
+		dp=malloc(sizeof(double));
+                if (have_rx_gain) {
+		  *dp=-12.0 + 0.6*(double) val;
+                } else {
+                  *dp = 0.31 * (double) val;
+                }
 		g_idle_add(ext_set_attenuation_value,(gpointer) dp);
 		break;
 	      default:

--- a/oc_menu.c
+++ b/oc_menu.c
@@ -172,7 +172,8 @@ void oc_menu(GtkWidget *parent) {
     //gtk_widget_override_font(oc_rx_title, pango_font_description_from_string("Arial 18"));
     gtk_widget_show(oc_rx_title);
     gtk_grid_attach(GTK_GRID(grid),oc_rx_title,i,2,1,1);
-    GtkWidget *oc_tx_title=gtk_label_new(oc_id);
+    GtkWidget *oc_tx_title=gtk_label_new(NULL);
+    gtk_label_set_markup(GTK_LABEL(oc_tx_title), oc_id);
     //gtk_widget_override_font(oc_tx_title, pango_font_description_from_string("Arial 18"));
     gtk_widget_show(oc_tx_title);
     gtk_grid_attach(GTK_GRID(grid),oc_tx_title,i+7,2,1,1);

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -1395,12 +1395,10 @@ if(last_power!=power) {
         if (have_rx_gain) {
 	  //
 	  // HERMESlite has a RXgain value in the range 0-60 that
-	  // is stored in gx_gain_slider. The firmware uses bit 6
-	  // of C4 to determine this case. However RadioBerry seems
-	  // to behave differently and stores bit5 of the gain in the
-	  // dither bit (see above) and a 5-bit attenuation value here.
+	  // is stored in rx_gain_slider. The firmware uses bit 6
+	  // of C4 to determine this case.
 	  //
-          int rxgain = - adc_attenuation[active_receiver->adc]+12; // -12..48 to 0..60
+          int rxgain = adc_attenuation[active_receiver->adc]+12; // -12..48 to 0..60
           if (rxgain <  0) rxgain=0;
           if (rxgain > 60) rxgain=60;
 	  // encode all 6 bits of RXgain in ATT value and set bit6

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -1286,10 +1286,10 @@ static int last_power=0;
           }
         }
 
-if(last_power!=power) {
-  g_print("power=%d\n",power);
-  last_power=power;
-}
+//if(last_power!=power) {
+//  g_print("power=%d\n",power);
+//  last_power=power;
+//}
 
 
 

--- a/rx_panadapter.c
+++ b/rx_panadapter.c
@@ -385,7 +385,7 @@ void rx_panadapter_update(RECEIVER *rx) {
   samples[0]=-200.0;
   samples[display_width-1]=-200.0;
   if(have_rx_gain) {
-    s1=(double)samples[0]+40.0-(adc_attenuation[rx->adc]+12.0);
+    s1=(double)samples[0]+rx_gain_calibration-adc_attenuation[rx->adc];
   } else {
     s1=(double)samples[0]+(double)adc_attenuation[rx->adc];
   }
@@ -406,7 +406,7 @@ void rx_panadapter_update(RECEIVER *rx) {
   cairo_move_to(cr, 0.0, s1);
   for(i=1;i<display_width;i++) {
     if(have_rx_gain) {
-      s2=(double)samples[i]+40.0-(adc_attenuation[rx->adc]+12.0);
+      s2=(double)samples[i]+rx_gain_calibration-adc_attenuation[rx->adc];
     } else {
       s2=(double)samples[i]+(double)adc_attenuation[rx->adc];
     }

--- a/tx_panadapter.c
+++ b/tx_panadapter.c
@@ -241,7 +241,7 @@ void tx_panadapter_update(TRANSMITTER *tx) {
   }
 
   // plot frequency markers
-  long long half=6000LL; //(long long)(tx->output_rate/2);
+  long long half= duplex ? 3000LL : 12000LL; //(long long)(tx->output_rate/2);
   long long frequency;
   if(vfo[txvfo].ctun) {
     frequency=vfo[txvfo].ctun_frequency;
@@ -262,7 +262,7 @@ void tx_panadapter_update(TRANSMITTER *tx) {
 #ifdef TX_FREQ_MARKERS
   cairo_text_extents_t extents;
   long long f;
-  long long divisor=50000;
+  long long divisor=2000;
   for(i=0;i<display_width;i++) {
     f = frequency - half + (long) (hz_per_pixel * i);
     if (f > 0) {

--- a/waterfall.c
+++ b/waterfall.c
@@ -172,7 +172,11 @@ void waterfall_update(RECEIVER *rx) {
     p=pixels;
     samples=rx->pixel_samples;
     for(i=0;i<width;i++) {
-            sample=samples[i]+adc_attenuation[rx->adc];
+            if(have_rx_gain) {
+              sample=samples[i]+(float)(rx_gain_calibration-adc_attenuation[rx->adc]);
+            } else {
+              sample=samples[i]+(float)adc_attenuation[rx->adc];
+            }
             average+=(int)sample;
             if(sample<(float)rx->waterfall_low) {
                 *p++=colorLowR;


### PR DESCRIPTION
- corrected TX panadapter frequency markers and band edges
- corrected analog RF output watt meter
- OC menu TX labels corrected
- put all ALC stuff in one column in the meter menu
- corrected HERMESlite rxgain setting in P1
- use rx_calibration_value in HL2 metering
- Attenuator Knob/Wheel in MIDI now correctly sets RXgain
  value on HL2
