### PR TITLE
Emergency fix: Changing bands while CTUN is active

### DIFF
--- a/vfo.c
+++ b/vfo.c
@@ -292,7 +292,7 @@ void vfo_band_changed(int b) {
   vfo[id].ctun=0;
   vfo[id].offset=0;
   // tell WDSP about the offset
-  set_offset(active_receiver, vfo[i].offset);
+  set_offset(active_receiver, vfo[id].offset);
 
   switch(id) {
     case 0:

--- a/vfo.c
+++ b/vfo.c
@@ -291,6 +291,8 @@ void vfo_band_changed(int b) {
   // turn off ctun
   vfo[id].ctun=0;
   vfo[id].offset=0;
+  // tell WDSP about the offset
+  set_offset(active_receiver, vfo[i].offset);
 
   switch(id) {
     case 0:


### PR DESCRIPTION
When changing the band while CTUN is active, the WDSP offset was not reset. This also happens when making a "long frequency jump" while CTUN is active.
 