### PR TITLE
Avoid segfaults when reading props file, and corrected the "floating" slider.

### DIFF
--- a/band.c
+++ b/band.c
@@ -503,6 +503,7 @@ void bandSaveState() {
 
 void bandRestoreState() {
     char* value;
+    int v;
     int b;
     int stack;
     char name[128];
@@ -513,13 +514,26 @@ void bandRestoreState() {
         value=getProperty(name);
         if(value) strcpy(bands[b].title,value);
 
-        sprintf(name,"band.%d.entries",b);
-        value=getProperty(name);
-        if(value) bands[b].bandstack->entries=atoi(value);
+	// The number of entries is a compile-time constant,
+        // which changes when compiling piHPSDR with different
+	// options (e.g. with and without SOAPYSDR)
+	// Therefore this number cannot be "restored" from a props file
+
+        //sprintf(name,"band.%d.entries",b);
+        //lue=getProperty(name);
+        //if(value) bands[b].bandstack->entries=atoi(value);
 
         sprintf(name,"band.%d.current",b);
         value=getProperty(name);
-        if(value) bands[b].bandstack->current_entry=atoi(value);
+        if(value) {
+	  //
+	  // Since the number of bandstack entries is a compile-time constant,
+	  // we cannot allow "current" to exceed the number of available slots
+	  //
+	  v=atoi(value);
+	  if (v >= bands[b].bandstack->entries) v=0;
+	  bands[b].bandstack->current_entry=v;
+	}
 
         sprintf(name,"band.%d.preamp",b);
         value=getProperty(name);

--- a/sliders.c
+++ b/sliders.c
@@ -158,6 +158,7 @@ static void attenuation_value_changed_cb(GtkWidget *widget, gpointer data) {
 
 void set_attenuation_value(double value) {
   adc_attenuation[active_receiver->adc]=(int)value;
+  set_attenuation(adc_attenuation[active_receiver->adc]);
   if(display_sliders) {
     if (have_rx_gain) {
 	gtk_range_set_value (GTK_RANGE(attenuation_scale),(double)adc_attenuation[active_receiver->adc]);
@@ -200,7 +201,6 @@ void set_attenuation_value(double value) {
       scale_timer=g_timeout_add(2000,scale_timeout_cb,NULL);
     }
   }
-  set_attenuation(adc_attenuation[active_receiver->adc]);
 }
 
 void update_att_preamp(void) {
@@ -703,6 +703,8 @@ void set_squelch() {
 }
 
 void set_compression(TRANSMITTER* tx) {
+  // Update VFO panel to reflect changed value
+  g_idle_add(ext_vfo_update, NULL);
 #ifdef COMPRESSION_SLIDER_INSTEAD_OF_SQUELCH
   if(display_sliders) {
     gtk_range_set_value (GTK_RANGE(comp_scale),tx->compressor_level);
@@ -735,8 +737,6 @@ void set_compression(TRANSMITTER* tx) {
 #ifdef COMPRESSION_SLIDER_INSTEAD_OF_SQUELCH
   }
 #endif
-  // Now we are also displaying the TX compressor value in the VFO panel
-  g_idle_add(ext_vfo_update, NULL);
 }
 
 void show_diversity_gain() {

--- a/zoompan.c
+++ b/zoompan.c
@@ -108,6 +108,7 @@ g_print("set_zoom: %f\n",value);
         scale_status=NO_FUNCTION;
       }
     }
+    receiver_change_zoom(active_receiver,value);
     if(scale_status==NO_FUNCTION) {
       scale_status=ZOOM;
       scale_rx=rx;
@@ -127,7 +128,6 @@ g_print("set_zoom: %f\n",value);
       gtk_range_set_value (GTK_RANGE(zoom_scale),receiver[rx]->zoom);
       scale_timer=g_timeout_add(2000,scale_timeout_cb,NULL);
     }
-    receiver_change_zoom(active_receiver,value);
   }
   vfo_update();
 }
@@ -180,6 +180,7 @@ g_print("set_pan: %f\n",value);
         scale_status=NO_FUNCTION;
       }
     }
+    receiver_change_pan(active_receiver,value);
     if(scale_status==NO_FUNCTION) {
       scale_status=PAN;
       scale_rx=rx;
@@ -199,7 +200,6 @@ g_print("set_pan: %f\n",value);
       gtk_range_set_value (GTK_RANGE(pan_scale),receiver[rx]->pan);
       scale_timer=g_timeout_add(2000,scale_timeout_cb,NULL);
     }
-    receiver_change_pan(active_receiver,gtk_range_get_value(GTK_RANGE(pan_scale)));
   }
 }
 


### PR DESCRIPTION
band.c: when reading the props file, put nothing in the data structures beyond compile-time boundaries (this happens if the number of bands has been reduced since the last compile, e.g. by de-activating SOAPY).

sliders.c/zoompan.c: the gtk_dialog_run() do not return as long as the "floating slider" is on the screen. So do everything that has to be done, has to be done before.

"floating slider": this is the slider that pops up for two seconds if a slider value changes (through MIDI, GPIO, CAT) but the sliders are not shown.