### PR TITLE
Memory protection violation fixed if number of found midi devices is …

### DIFF
--- a/alsa_midi.c
+++ b/alsa_midi.c
@@ -243,7 +243,6 @@ void get_midi_devices() {
     snd_rawmidi_info_t *info;
     int card, device, subs, sub, ret;
     const char *devnam, *subnam;
-    int found=0;
     char name[64];
 
     n_midi_devices=0;
@@ -282,6 +281,7 @@ void get_midi_devices() {
 	    if (!subs) break;
 	    // subs: number of sub-devices to device on card
             for (sub = 0; sub < subs; ++sub) {
+		if (n_midi_devices >= MAX_MIDI_DEVICES) break;
                 snd_rawmidi_info_set_stream(info, SND_RAWMIDI_STREAM_INPUT);
                 snd_rawmidi_info_set_subdevice(info, sub);
                 ret = snd_ctl_rawmidi_info(ctl, info);
@@ -290,7 +290,6 @@ void get_midi_devices() {
                                    card, device, sub, snd_strerror(ret));
                     break;
                 }
-		if (found) break;
 		devnam = snd_rawmidi_info_get_name(info);
 		subnam = snd_rawmidi_info_get_subdevice_name(info);
 		// If there is only one sub-device and it has no name, we  use
@@ -300,7 +299,11 @@ void get_midi_devices() {
 		    sprintf(portname,"hw:%d,%d", card, device);
 		} else {
 		    sprintf(portname,"hw:%d,%d,%d", card, device, sub);
-		    devnam=subnam;
+		    if (subnam[0] == '\0') {
+			devnam = portname;
+		    } else {
+			devnam = subnam;
+		    }
 		}
 
 		midi_devices[n_midi_devices].name=g_new(gchar,strlen(devnam)+1);


### PR DESCRIPTION
…greater than declared in MAX_MIDI_DEVICES.

In the case of more subdevices midi (e.g. virmidi - virtual midi has 16 subdevices) on the list there were empty items in the absence of the subdevice name.