### PR TITLE
add remote audio output option for each RX

### DIFF
--- a/receiver.c
+++ b/receiver.c
@@ -179,6 +179,9 @@ void receiver_save_state(RECEIVER *rx) {
   sprintf(name,"receiver.%d.audio_channel",rx->id);
   sprintf(value,"%d",rx->audio_channel);
   setProperty(name,value);
+  sprintf(name,"receiver.%d.remote_audio",rx->id);
+  sprintf(value,"%d",rx->remote_audio);
+  setProperty(name,value);
   sprintf(name,"receiver.%d.local_audio",rx->id);
   sprintf(value,"%d",rx->local_audio);
   setProperty(name,value);
@@ -349,6 +352,9 @@ fprintf(stderr,"receiver_restore_state: id=%d\n",rx->id);
   sprintf(name,"receiver.%d.audio_channel",rx->id);
   value=getProperty(name);
   if(value) rx->audio_channel=atoi(value);
+  sprintf(name,"receiver.%d.remote_audio",rx->id);
+  value=getProperty(name);
+  if(value) rx->remote_audio=atoi(value);
   sprintf(name,"receiver.%d.local_audio",rx->id);
   value=getProperty(name);
   if(value) rx->local_audio=atoi(value);
@@ -907,6 +913,7 @@ fprintf(stderr,"create_pure_signal_receiver: id=%d buffer_size=%d\n",id,buffer_s
   rx->audio_channel=STEREO;
   rx->audio_device=-1;
   rx->mute_radio=0;
+  rx->remote_audio=1;
 
   rx->low_latency=0;
 
@@ -1040,6 +1047,7 @@ fprintf(stderr,"create_receiver: id=%d default adc=%d\n",rx->id, rx->adc);
   rx->mute_when_not_active=0;
   rx->audio_channel=STEREO;
   rx->audio_device=-1;
+  rx->remote_audio=1;
 
   rx->low_latency=0;
 
@@ -1068,7 +1076,7 @@ fprintf(stderr,"create_receiver: id=%d default adc=%d\n",rx->id, rx->adc);
   rx->pixel_samples=g_new(float,rx->pixels);
 
 
-fprintf(stderr,"create_receiver (after restore): rx=%p id=%d audio_buffer_size=%d local_audio=%d\n",rx,rx->id,rx->audio_buffer_size,rx->local_audio);
+fprintf(stderr,"create_receiver (after restore): rx=%p id=%d audio_buffer_size=%d local_audio=%d remote_audio=%d\n",rx,rx->id,rx->audio_buffer_size,rx->local_audio,rx->remote_audio);
   //rx->audio_buffer=g_new(guchar,rx->audio_buffer_size);
   int scale=rx->sample_rate/48000;
   rx->output_samples=rx->buffer_size/scale;
@@ -1356,7 +1364,7 @@ static void process_rx_buffer(RECEIVER *rx) {
           if(rx->mute_radio) {
             old_protocol_audio_samples(rx,(short)0,(short)0);
           } else {
-            old_protocol_audio_samples(rx,left_audio_sample,right_audio_sample);
+            old_protocol_audio_samples(rx, rx->remote_audio ? left_audio_sample : (short)0, rx->remote_audio ? right_audio_sample : (short)0);
           }
           break;
         case NEW_PROTOCOL:
@@ -1364,7 +1372,7 @@ static void process_rx_buffer(RECEIVER *rx) {
             if(rx->mute_radio) {
               new_protocol_audio_samples(rx,(short)0,(short)0);
             } else {
-              new_protocol_audio_samples(rx,left_audio_sample,right_audio_sample);
+              new_protocol_audio_samples(rx, rx->remote_audio ? left_audio_sample : (short)0, rx->remote_audio ? right_audio_sample : (short)0);
             }
           }
           break;

--- a/receiver.h
+++ b/receiver.h
@@ -128,6 +128,8 @@ typedef struct _receiver {
   void *local_audio_buffer;
   GMutex local_audio_mutex;
 
+  gboolean remote_audio;
+
   gint low_latency;
 
   gint squelch_enable;

--- a/rx_menu.c
+++ b/rx_menu.c
@@ -39,6 +39,7 @@ static GtkWidget *menu_b=NULL;
 static GtkWidget *dialog=NULL;
 static GtkWidget *local_audio_b=NULL;
 static GtkWidget *output=NULL;
+static GtkWidget *remote_audio_b=NULL;
 
 static void cleanup() {
   if(dialog!=NULL) {
@@ -125,6 +126,11 @@ fprintf(stderr,"local_audio_cb: audio_open_output failed\n");
     }
   }
 fprintf(stderr,"local_audio_cb: local_audio=%d\n",active_receiver->local_audio);
+}
+
+static void remote_audio_cb(GtkWidget *widget, gpointer data) {
+  fprintf(stderr,"remote_audio_cb: rx=%d\n",active_receiver->id);
+  active_receiver->remote_audio=gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget));
 }
 
 static void mute_audio_cb(GtkWidget *widget, gpointer data) {
@@ -353,8 +359,18 @@ void rx_menu(GtkWidget *parent) {
     x++;
   }
 
-
   int row=0;
+
+  // radio that don't have remote audio codec
+  // should not visualize the option
+  if (radio->device != DEVICE_HERMES_LITE2) {
+    remote_audio_b=gtk_check_button_new_with_label("Remote Audio Output");
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (remote_audio_b), active_receiver->remote_audio);
+    gtk_widget_show(remote_audio_b);
+    gtk_grid_attach(GTK_GRID(grid),remote_audio_b,x,++row,1,1);
+    g_signal_connect(remote_audio_b,"toggled",G_CALLBACK(remote_audio_cb),NULL);
+  }
+
   if(n_output_devices>0) {
     local_audio_b=gtk_check_button_new_with_label("Local Audio Output");
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (local_audio_b), active_receiver->local_audio);


### PR DESCRIPTION
we can enable or disable the remote audio output for each receiver.
The audio volume remains the same for local and remote audio.