### PR TITLE
Soapy TX, GPIO, "actions" corrrections

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -1,4 +1,5 @@
 #include <gtk/gtk.h>
+#include <math.h>
 
 #include "main.h"
 #include "discovery.h"
@@ -68,8 +69,8 @@ ACTION_TABLE ActionTable[] = {
   {BAND_902,		"BAND 902",		"902",		MIDI_KEY},
   {BAND_AIR,		"BAND AIR",		"AIR",		MIDI_KEY},
   {BAND_GEN,		"BAND GEN",		"GEN",		MIDI_KEY},
-  {BAND_MINUS,		"BAND -",		"BND+",		MIDI_KEY | CONTROLLER_SWITCH},
-  {BAND_PLUS,		"BAND +",		"BND-",		MIDI_KEY | CONTROLLER_SWITCH},
+  {BAND_MINUS,		"BAND -",		"BND-",		MIDI_KEY | CONTROLLER_SWITCH},
+  {BAND_PLUS,		"BAND +",		"BND+",		MIDI_KEY | CONTROLLER_SWITCH},
   {BAND_WWV,		"BAND WWV",		"WWV",		MIDI_KEY},
   {BANDSTACK_MINUS,	"BANDSTACK -",		"BSTK-",	MIDI_KEY | CONTROLLER_SWITCH},
   {BANDSTACK_PLUS,	"BANDSTACK +",		"BSTK+",	MIDI_KEY | CONTROLLER_SWITCH},
@@ -81,23 +82,23 @@ ACTION_TABLE ActionTable[] = {
   {CW_RIGHT,		"CW RIGHT",		"CWR",		MIDI_KEY | CONTROLLER_SWITCH},
   {CW_SPEED,		"CW SPEED",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
   {DIV,			"DIV ON/OFF",		"DIV",		MIDI_KEY | CONTROLLER_SWITCH},
-  {DIV_GAIN,		"DIV GAIN",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {DIV_GAIN_COARSE,	"DIV GAIN\nCOARSE",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {DIV_GAIN_FINE,	"DIV GAIN\nFINE",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {DIV_PHASE,		"DIV PHASE",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {DIV_PHASE_COARSE,	"DIV PHASE\nCOARSE",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {DIV_PHASE_FINE,	"DIV PHASE\nFINE",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
+  {DIV_GAIN,		"DIV GAIN",		NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {DIV_GAIN_COARSE,	"DIV GAIN\nCOARSE",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {DIV_GAIN_FINE,	"DIV GAIN\nFINE",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {DIV_PHASE,		"DIV PHASE",		NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {DIV_PHASE_COARSE,	"DIV PHASE\nCOARSE",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {DIV_PHASE_FINE,	"DIV PHASE\nFINE",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
   {DRIVE,		"TX DRIVE",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
   {DUPLEX,		"DUPLEX",		"DUP",		MIDI_KEY | CONTROLLER_SWITCH},
-  {FILTER_MINUS,	"FILTER +",		"FL+",		MIDI_KEY | CONTROLLER_SWITCH},
-  {FILTER_PLUS,		"FILTER -",		"FL-",		MIDI_KEY | CONTROLLER_SWITCH},
+  {FILTER_MINUS,	"FILTER -",		"FL-",		MIDI_KEY | CONTROLLER_SWITCH},
+  {FILTER_PLUS,		"FILTER +",		"FL+",		MIDI_KEY | CONTROLLER_SWITCH},
   {FUNCTION,		"FUNC",			"FUNC",		CONTROLLER_SWITCH},
-  {IF_SHIFT,		"IF SHIFT",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {IF_SHIFT_RX1,	"IF SHIFT\nRX1",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {IF_SHIFT_RX2,	"IF SHIFT\nRX2",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {IF_WIDTH,		"IF WIDTH",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {IF_WIDTH_RX1,	"IF WIDTH\nRX1",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {IF_WIDTH_RX2,	"IF WIDTH\nRX2",	NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
+  {IF_SHIFT,		"IF SHIFT",		NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {IF_SHIFT_RX1,	"IF SHIFT\nRX1",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {IF_SHIFT_RX2,	"IF SHIFT\nRX2",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {IF_WIDTH,		"IF WIDTH",		NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {IF_WIDTH_RX1,	"IF WIDTH\nRX1",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {IF_WIDTH_RX2,	"IF WIDTH\nRX2",	NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
   {LINEIN_GAIN,		"LINEIN\nGAIN",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
   {LOCK,		"LOCK",			"LOCK",		MIDI_KEY | CONTROLLER_SWITCH},
   {MENU_AGC,		"AGC\nMENU",		"AGC",		MIDI_KEY | CONTROLLER_SWITCH},
@@ -129,7 +130,7 @@ ACTION_TABLE ActionTable[] = {
   {NUMPAD_9,		"NUMPAD 9",		"9",		MIDI_KEY},
   {NUMPAD_CL,		"NUMPAD\nCL",		"CL",		MIDI_KEY},
   {NUMPAD_ENTER,	"NUMPAD\nENTER",	"EN",		MIDI_KEY},
-  {PAN,			"PAN",			NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
+  {PAN,			"PAN",			NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
   {PAN_MINUS,		"PAN -",		"PAN-",		MIDI_KEY | CONTROLLER_SWITCH},
   {PAN_PLUS,		"PAN +",		"PAN+",		MIDI_KEY | CONTROLLER_SWITCH},
   {PANADAPTER_HIGH,	"PAN HIGH",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
@@ -141,13 +142,13 @@ ACTION_TABLE ActionTable[] = {
   {RF_GAIN,		"RF GAIN",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
   {RF_GAIN_RX1,		"RF GAIN\nRX1",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
   {RF_GAIN_RX2,		"RF GAIN\nRX2",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {RIT,			"RIT",			NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
+  {RIT,			"RIT",			NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
   {RIT_CLEAR,		"RIT\nCLEAR",		"RITCL",	MIDI_KEY | CONTROLLER_SWITCH},
   {RIT_ENABLE,		"RIT\nON/OFF",		"RIT",		MIDI_KEY | CONTROLLER_SWITCH},
   {RIT_MINUS,		"RIT +",		"RIT-",		MIDI_KEY | CONTROLLER_SWITCH},
   {RIT_PLUS,		"RIT -",		"RIT+",		MIDI_KEY | CONTROLLER_SWITCH},
-  {RIT_RX1,		"RIT\nRX1",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
-  {RIT_RX2,		"RIT\nRX2",		NULL,		MIDI_KNOB | MIDI_WHEEL | CONTROLLER_ENCODER},
+  {RIT_RX1,		"RIT\nRX1",		NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
+  {RIT_RX2,		"RIT\nRX2",		NULL,		MIDI_WHEEL | CONTROLLER_ENCODER},
   {RIT_STEP,		"RIT\nSTEP",		"RITST",	MIDI_KEY | CONTROLLER_SWITCH},
   {RSAT,		"RSAT",			"RSAT",		MIDI_KEY | CONTROLLER_SWITCH},
   {SAT,			"SAT",			"SAT",		MIDI_KEY | CONTROLLER_SWITCH},
@@ -196,7 +197,34 @@ static int timeout_cb(gpointer data) {
   return TRUE;
 }
 
-
+static inline double KnobOrWheel(PROCESS_ACTION *a, double oldval, double minval, double maxval, double inc) {
+  //
+  // Knob ("Potentiometer"):  set value
+  // Wheel("Rotary Encoder"): increment/decrement the value (by "inc" per tick)
+  //
+  // In both cases, the returned value is
+  //  - in the range minval...maxval
+  //  - rounded to a multiple of inc
+  //
+  switch (a->mode) {
+    case RELATIVE:
+      oldval += a->val * inc;
+      break;
+    case ABSOLUTE:
+      oldval = minval + a->val*(maxval-minval)*0.01;
+      break;
+    default:
+      // do nothing
+      break;
+  }
+  //
+  // Round and check range
+  //
+  oldval=inc*round(oldval/inc);
+  if (oldval > maxval) oldval=maxval;
+  if (oldval < minval) oldval=minval;
+  return oldval;
+}
 
 int process_action(void *data) {
   PROCESS_ACTION *a=(PROCESS_ACTION *)data;
@@ -224,40 +252,15 @@ int process_action(void *data) {
       }
       break;
     case AF_GAIN:
-      value=active_receiver->volume;
-      switch(a->mode) {
-	case RELATIVE:
-          value+=a->val/100.0;
-	  break;
-	case ABSOLUTE:
-	  value=a->val/100.0;
-	  break;
-      }
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>1.0) {
-        value=1.0;
-      }
+      value=KnobOrWheel(a, active_receiver->volume, 0.0, 1.0, 0.01);
       set_af_gain(active_receiver->id,value);
       break;
     case AF_GAIN_RX1:
-      value=receiver[0]->volume;
-      value+=a->val/100.0;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>1.0) {
-        value=1.0;
-      }
+      value=KnobOrWheel(a, receiver[0]->volume, 0.0, 1.0, 0.01);
       set_af_gain(0,value);
       break;
     case AF_GAIN_RX2:
-      value=receiver[1]->volume;
-      value+=a->val/100.0;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>1.0) {
-        value=1.0;
-      }
+      value=KnobOrWheel(a, receiver[1]->volume, 0.0, 1.0, 0.01);
       set_af_gain(1,value);
       break;
     case AGC:
@@ -271,33 +274,15 @@ int process_action(void *data) {
       }
       break;
     case AGC_GAIN:
-      value=active_receiver->agc_gain;
-      value+=a->val;
-      if(value<-20.0) {
-        value=-20.0;
-      } else if(value>120.0) {
-        value=120.0;
-      }
+      value=KnobOrWheel(a, active_receiver->agc_gain, -20.0, 120.0, 1.0);
       set_agc_gain(active_receiver->id,value);
       break;
     case AGC_GAIN_RX1:
-      value=receiver[0]->agc_gain;
-      value+=a->val;
-      if(value<-20.0) {
-        value=-20.0;
-      } else if(value>120.0) {
-        value=120.0;
-      }
+      value=KnobOrWheel(a, receiver[0]->agc_gain, -20.0, 120.0, 1.0);
       set_agc_gain(0,value);
       break;
     case AGC_GAIN_RX2:
-      value=receiver[1]->agc_gain;
-      value+=a->val;
-      if(value<-20.0) {
-        value=-20.0;
-      } else if(value>120.0) {
-        value=120.0;
-      }
+      value=KnobOrWheel(a, receiver[1]->agc_gain, -20.0, 120.0, 1.0);
       set_agc_gain(1,value);
       break;
     case ANF:
@@ -314,21 +299,7 @@ int process_action(void *data) {
       }
       break;
     case ATTENUATION:
-      value=(double)adc[active_receiver->adc].attenuation;
-      value+=(double)a->val;
-      if(have_rx_gain) {
-        if(value<-12.0) {
-          value=-12.0;
-        } else if(value>48.0) {
-          value=48.0;
-        }
-      } else {
-        if(value<0.0) {
-          value=0.0;
-        } else if (value>31.0) {
-          value=31.0;
-        }
-      }
+      value=KnobOrWheel(a, adc[active_receiver->adc].attenuation,   0.0, 31.0, 1.0);
       set_attenuation_value(value);
       break;
     case B_TO_A:
@@ -531,14 +502,10 @@ int process_action(void *data) {
       break;
     case COMPRESSION:
       if(can_transmit) {
-        value=transmitter->compressor_level;
-        value+=a->val;
-        if(value<0.0) {
-          value=0.0;
-        } else if(value>20.0) {
-          value=20.0;
-        }
-	transmitter_set_compressor_level(transmitter,value);
+        value=KnobOrWheel(a, transmitter->compressor_level, 0.0, 20.0, 1.0);
+        transmitter_set_compressor_level(transmitter,value);
+        transmitter_set_compressor(transmitter, value > 0.5);
+        g_idle_add(ext_vfo_update, NULL);
       }
       break;
     case CTUN:
@@ -554,13 +521,7 @@ int process_action(void *data) {
       break;
     case CW_FREQUENCY:
 #ifdef LOCALCW
-      value=(double)cw_keyer_sidetone_frequency;
-      value+=(double)a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>1000.0) {
-        value=1000.0;
-      }
+      value=KnobOrWheel(a, (double)cw_keyer_sidetone_frequency, 300.0, 1000.0, 10.0);
       cw_keyer_sidetone_frequency=(int)value;
       g_idle_add(ext_vfo_update,NULL);
 #endif
@@ -575,13 +536,7 @@ int process_action(void *data) {
       break;
     case CW_SPEED:
 #ifdef LOCALCW
-      value=(double)cw_keyer_speed;
-      value+=(double)a->val;
-      if(value<1.0) {
-        value=1.0;
-      } else if(value>60.0) {
-        value=60.0;
-      }
+      value=KnobOrWheel(a, (double)cw_keyer_speed, 1.0, 60.0, 1.0);
       cw_keyer_speed=(int)value;
       g_idle_add(ext_vfo_update,NULL);
 #endif
@@ -615,17 +570,11 @@ int process_action(void *data) {
       update_diversity_phase((double)a->val*0.1);
       break;
     case DRIVE:
-      value=getDrive();
-      value+=(double)a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>drive_max) {
-        value=drive_max;
-      }
+      value=KnobOrWheel(a, getDrive(), 0.0, drive_max, 1.0);
       set_drive(value);
       break;
     case DUPLEX:
-      if(can_transmit && !isTransmitting()) {
+      if(can_transmit && !isTransmitting() && a->mode == PRESSED) {
         duplex=duplex==1?0:1;
         g_idle_add(ext_set_duplex, NULL);
       }
@@ -753,13 +702,7 @@ int process_action(void *data) {
       break;
 #endif
     case MIC_GAIN:
-      value=mic_gain;
-      value+=(double)a->val;
-      if(value<-12.0) {
-        value=-12.0;
-      } else if(value>50.0) {
-        value=50.0;
-      }
+      value=KnobOrWheel(a, mic_gain, -12.0, 50.0, 1.0);
       set_mic_gain(value);
       break;
     case MODE_MINUS:
@@ -892,18 +835,15 @@ int process_action(void *data) {
        }
        break;
     case PANADAPTER_HIGH:
-      value=(double)active_receiver->panadapter_high;
-      value+=(double)a->val;
+      value=KnobOrWheel(a, active_receiver->panadapter_high, -60.0, 20.0, 1.0);
       active_receiver->panadapter_high=(int)value;
       break;
     case PANADAPTER_LOW:
-      value=(double)active_receiver->panadapter_low;
-      value+=(double)a->val;
+      value=KnobOrWheel(a, active_receiver->panadapter_low, -160.0, -60.0, 1.0);
       active_receiver->panadapter_low=(int)value;
       break;
     case PANADAPTER_STEP:
-      value=(double)active_receiver->panadapter_step;
-      value+=(double)a->val;
+      value=KnobOrWheel(a, active_receiver->panadapter_step, 5.0, 30.0, 1.0);
       active_receiver->panadapter_step=(int)value;
       break;
     case PREAMP:
@@ -926,33 +866,15 @@ int process_action(void *data) {
       }
       break;
     case RF_GAIN:
-      value=adc[active_receiver->id].gain;
-      value+=a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>100.0) {
-        value=100.0;
-      }
+      value=KnobOrWheel(a, adc[active_receiver->adc].gain, adc[active_receiver->adc].min_gain, adc[active_receiver->adc].max_gain, 1.0);
       set_rf_gain(active_receiver->id,value);
       break;
     case RF_GAIN_RX1:
-      value=adc[receiver[0]->id].gain;
-      value+=a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>100.0) {
-        value=100.0;
-      }
+      value=KnobOrWheel(a, adc[receiver[0]->adc].gain, adc[receiver[0]->adc].min_gain, adc[receiver[0]->adc].max_gain, 1.0);
       set_rf_gain(0,value);
       break;
     case RF_GAIN_RX2:
-      value=adc[receiver[1]->id].gain;
-      value+=a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>71.0) {
-        value=71.0;
-      }
+      value=KnobOrWheel(a, adc[receiver[1]->adc].gain, adc[receiver[1]->adc].min_gain, adc[receiver[1]->adc].max_gain, 1.0);
       set_rf_gain(1,value);
       break;
     case RIT:
@@ -1049,35 +971,17 @@ int process_action(void *data) {
       }
       break;
     case SQUELCH:
-      value=active_receiver->squelch;
-      value+=(double)a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>100.0) {
-        value=100.0;
-      }
+      value=KnobOrWheel(a, active_receiver->squelch, 0.0, 100.0, 1.0);
       active_receiver->squelch=value;
       set_squelch(active_receiver);
       break;
     case SQUELCH_RX1:
-      value=receiver[0]->squelch;
-      value+=(double)a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>100.0) {
-        value=100.0;
-      }
+      value=KnobOrWheel(a, receiver[0]->squelch, 0.0, 100.0, 1.0);
       receiver[0]->squelch=value;
       set_squelch(receiver[0]);
       break;
     case SQUELCH_RX2:
-      value=receiver[1]->squelch;
-      value+=(double)a->val;
-      if(value<0.0) {
-        value=0.0;
-      } else if(value>100.0) {
-        value=100.0;
-      }
+      value=KnobOrWheel(a, receiver[1]->squelch, 0.0, 100.0, 1.0);
       receiver[1]->squelch=value;
       set_squelch(receiver[1]);
       break;
@@ -1110,23 +1014,8 @@ int process_action(void *data) {
       break;
     case TUNE_DRIVE:
       if(can_transmit) {
-        switch(a->mode) {
-          case RELATIVE:
-            if(a->val>0) {
-              transmitter->tune_percent=transmitter->tune_percent+1;
-	    }
-            if(a->val<0) {
-              transmitter->tune_percent=transmitter->tune_percent-1;
-	    }
-	    if(transmitter->tune_percent<0) transmitter->tune_percent=0;
-	    if(transmitter->tune_percent>100) transmitter->tune_percent=100;
-            break;
-          case ABSOLUTE:
-	    transmitter->tune_percent=(int)a->val;
-	    if(transmitter->tune_percent<0) transmitter->tune_percent=0;
-	    if(transmitter->tune_percent>100) transmitter->tune_percent=100;
-            break;
-        }
+        value=KnobOrWheel(a, (double) transmitter->tune_percent, 0.0, 100.0, 1.0);
+        transmitter->tune_percent=(int) value;
       }
       break;
     case TUNE_FULL:
@@ -1185,32 +1074,18 @@ int process_action(void *data) {
       g_idle_add(ext_vfo_update, NULL);
       break;
     case VOXLEVEL:
-      if(a->mode==ABSOLUTE) {
-	vox_threshold = 0.01 * a->val;
-      } else if(a->mode==RELATIVE) {
-        vox_threshold += a->val * 0.01;
-        if (vox_threshold > 1.0) vox_threshold=1.0;
-        if (vox_threshold < 0.0) vox_threshold=0.0;
-      }
+      vox_threshold=KnobOrWheel(a, vox_threshold, 0.0, 1.0, 0.01);
       break;
     case WATERFALL_HIGH:
-      value=(double)active_receiver->waterfall_high;
-      value+=(double)a->val;
+      value=KnobOrWheel(a, active_receiver->waterfall_high, -100.0, 0.0, 1.0);
       active_receiver->waterfall_high=(int)value;
       break;
     case WATERFALL_LOW:
-      value=(double)active_receiver->waterfall_low;
-      value+=(double)a->val;
+      value=KnobOrWheel(a, active_receiver->waterfall_low, -150.0, -50.0, 1.0);
       active_receiver->waterfall_low=(int)value;
       break;
     case XIT:
-      value=(double)transmitter->xit;
-      value+=(double)(a->val*rit_increment);
-      if(value<-10000.0) {
-        value=-10000.0;
-      } else if(value>10000.0) {
-        value=10000.0;
-      }
+      value=KnobOrWheel(a, (double)transmitter->xit, -10000.0, 10000.0, (double) rit_increment);
       transmitter->xit=(int)value;
       transmitter->xit_enabled=(value!=0);
       if(protocol==NEW_PROTOCOL) {

--- a/soapy_protocol.c
+++ b/soapy_protocol.c
@@ -408,8 +408,18 @@ void soapy_protocol_iq_samples(float isample,float qsample) {
   long long timeNs=0;
   long timeoutUs=100000L;
   if(isTransmitting()) {
-    output_buffer[(output_buffer_index*2)]=isample;
-    output_buffer[(output_buffer_index*2)+1]=qsample;
+    //
+    // The "iqswap" logic has now been removed  from transmitter.c
+    // and moved here, because this is where it is also handled
+    // upon RX.
+    //
+    if (iqswap) {
+      output_buffer[(output_buffer_index*2)]=qsample;
+      output_buffer[(output_buffer_index*2)+1]=isample;
+    } else {
+      output_buffer[(output_buffer_index*2)]=isample;
+      output_buffer[(output_buffer_index*2)+1]=qsample;
+    }
     output_buffer_index++;
     if(output_buffer_index>=max_tx_samples) {
       int elements=SoapySDRDevice_writeStream(soapy_device,tx_stream,tx_buffs,max_tx_samples,&flags,timeNs,timeoutUs);

--- a/transmitter.c
+++ b/transmitter.c
@@ -802,6 +802,8 @@ fprintf(stderr,"create_transmitter: id=%d buffer_size=%d mic_sample_rate=%d mic_
   tx->dialog_x=-1;
   tx->dialog_y=-1;
 
+  tx->alc=0.0;
+
   transmitter_restore_state(tx);
 
 
@@ -1135,13 +1137,8 @@ static void full_tx_buffer(TRANSMITTER *tx) {
 	//
 	for(j=0;j<tx->output_samples;j++) {
             double is,qs;
-            if(iqswap) {
-	      qs=tx->iq_output_buffer[j*2];
-	      is=tx->iq_output_buffer[(j*2)+1];
-            } else {
-	      is=tx->iq_output_buffer[j*2];
-	      qs=tx->iq_output_buffer[(j*2)+1];
-            }
+	    is=tx->iq_output_buffer[j*2];
+	    qs=tx->iq_output_buffer[(j*2)+1];
 	    isample=is>=0.0?(long)floor(is*gain+0.5):(long)ceil(is*gain-0.5);
 	    qsample=qs>=0.0?(long)floor(qs*gain+0.5):(long)ceil(qs*gain-0.5);
 	    switch(protocol) {
@@ -1153,7 +1150,7 @@ static void full_tx_buffer(TRANSMITTER *tx) {
 		    break;
 #ifdef SOAPYSDR
                 case SOAPYSDR_PROTOCOL:
-                    soapy_protocol_iq_samples((float)isample,(float)qsample);
+                    soapy_protocol_iq_samples((float)is,(float)qs);
                     break;
 #endif
 	    }


### PR DESCRIPTION
TRANSMITTER
============

- normalize the Soapy TX IQ samples to 1.0 for full amplitude
- move TX "iqswap" logic from transmitter.c to soapy_protocol.c in analogy to RX chain
- init tx->alc since bogus values here can lead to segfaults (sprintf overflow) if printed
   before the first TX buffer is full

GPIO
====

- add debouncing to encoder switches
- fixed value when reporting switches upstream
- removed unused global variable switch_debounce
- result of millis() is unsigned
- disable CW_BUTTONS etc. for controller2v2 (no spare I/O lines)

actions.c
=======

- Fixed some of the "button texts" (see BAND_MINUS)
- removed MIDI_KNOB from actions table where it is not supported
- new function KnobOrWheel (static inline), that does all the Knob/Wheel discrimination
  including range checking etc., this makes the "process_action" function *much*
  more compact and maintennce-friendly (the "inline" attribute is perhaps not needed).

