### PR TITLE
Fix SWR calculation

### DIFF
--- a/meter.c
+++ b/meter.c
@@ -462,8 +462,8 @@ if(analog_meter) {
       double swr;
       if (max_level > reverse) {
         //swr=(max_level+reverse)/(max_level-reverse);
-	// fix fhanks to JW1TWP
-	swr=(1+sqrt(max_level/reverse))/(1-sqrt(max_level/reverse));
+	// fix thanks to JW1TWP
+	swr=(1+sqrt(reverse/max_level))/(1-sqrt(reverse/max_level));
       } else {
         swr=999.9;
       }


### PR DESCRIPTION
I've noticed the SWR is always in negative value and also sometimes shows "-nan". Here is a simple fix. 
-K9SUL / HL1SUL