### PR TITLE
update offers a dark mode compatible collection of Gdk background overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GIT_VERSION := $(shell git describe --abbrev=0 --tags)
 #    CONTROLLER2_V1 single encoders with MCP23017 switches
 #    CONTROLLER2_V2 dual encoders with MCP23017 switches
 #
-GPIO_INCLUDE=GPIO
+#GPIO_INCLUDE=GPIO
 
 # uncomment the line below to include Pure Signal support
 PURESIGNAL_INCLUDE=PURESIGNAL
@@ -45,6 +45,9 @@ PURESIGNAL_INCLUDE=PURESIGNAL
 #DEBUG_OPTION=-D DEBUG
 
 #PTT_INCLUDE=PTT
+
+# dark mode compatibility (otherwise we get white text on white background)
+BKGND_OPTION=-D BKGND
 
 # very early code not included yet
 #SERVER_INCLUDE=SERVER
@@ -198,6 +201,7 @@ OPTIONS=$(SMALL_SCREEN_OPTIONS) $(MIDI_OPTIONS) $(PURESIGNAL_OPTIONS) $(REMOTE_O
         $(PTT_OPTIONS) \
 	$(SERVER_OPTIONS) \
 	$(AUDIO_OPTIONS) \
+	$(BKGND_OPTION) \
 	-D GIT_DATE='"$(GIT_DATE)"' -D GIT_VERSION='"$(GIT_VERSION)"' $(DEBUG_OPTION)
 
 

--- a/about_menu.c
+++ b/about_menu.c
@@ -71,13 +71,17 @@ void about_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
-
+#endif
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
   GtkWidget *grid=gtk_grid_new();

--- a/agc_menu.c
+++ b/agc_menu.c
@@ -85,12 +85,17 @@ void agc_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/ant_menu.c
+++ b/ant_menu.c
@@ -311,12 +311,17 @@ void ant_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - ANT");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/band_menu.c
+++ b/band_menu.c
@@ -93,12 +93,17 @@ void band_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/bandstack_menu.c
+++ b/bandstack_menu.c
@@ -92,12 +92,17 @@ void bandstack_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/bkgnd.h
+++ b/bkgnd.h
@@ -1,0 +1,1 @@
+static GdkRGBA bkgnd_color={0.06,0.45,0.00,1.00};

--- a/cw_menu.c
+++ b/cw_menu.c
@@ -145,12 +145,17 @@ void cw_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - CW");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/discovery.c
+++ b/discovery.c
@@ -53,7 +53,9 @@
 #include "client_server.h"
 #endif
 #include "property.h"
-
+#ifdef BKGND
+#include "bkgnd.h"
+#endif
 static GtkWidget *discovery_dialog;
 static DISCOVERED *d;
 
@@ -282,13 +284,17 @@ void discovery() {
     //gtk_widget_override_font(discovery_dialog, pango_font_description_from_string("FreeMono 16"));
     g_signal_connect(discovery_dialog, "delete_event", G_CALLBACK(delete_event_cb), NULL);
 
-    GdkRGBA color;
-    color.red = 1.0;
-    color.green = 1.0;
-    color.blue = 1.0;
-    color.alpha = 1.0;
-    gtk_widget_override_background_color(discovery_dialog,GTK_STATE_FLAG_NORMAL,&color);
-
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(discovery_dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
+  GdkRGBA color;
+  color.red = 1.0;
+  color.green = 1.0;
+  color.blue = 1.0;
+  color.alpha = 1.0;
+  gtk_widget_override_background_color(discovery_dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
     GtkWidget *content;
 
     content=gtk_dialog_get_content_area(GTK_DIALOG(discovery_dialog));

--- a/display_menu.c
+++ b/display_menu.c
@@ -152,12 +152,17 @@ void display_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Display");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/diversity_menu.c
+++ b/diversity_menu.c
@@ -192,12 +192,17 @@ void diversity_menu(GtkWidget *parent) {
   gain_fine=div_gain-gain_coarse;
   phase_coarse=4.0*round(div_phase*0.25);
   phase_fine=div_phase-phase_coarse;
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/dsp_menu.c
+++ b/dsp_menu.c
@@ -100,12 +100,17 @@ void dsp_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - DSP");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/equalizer_menu.c
+++ b/equalizer_menu.c
@@ -123,12 +123,17 @@ void equalizer_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Equalizer");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/exit_menu.c
+++ b/exit_menu.c
@@ -171,13 +171,17 @@ void exit_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Exit");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
-
+#endif
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
   GtkWidget *grid=gtk_grid_new();

--- a/fft_menu.c
+++ b/fft_menu.c
@@ -75,12 +75,17 @@ void fft_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - FFT");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/filter_menu.c
+++ b/filter_menu.c
@@ -132,12 +132,17 @@ void filter_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/fm_menu.c
+++ b/fm_menu.c
@@ -71,12 +71,17 @@ void fm_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - FM");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/freqent_menu.c
+++ b/freqent_menu.c
@@ -161,12 +161,17 @@ void freqent_menu(GtkWidget *parent) {
     gtk_window_set_title(GTK_WINDOW(dialog),title);
     g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
-    GdkRGBA color;
-    color.red = 1.0;
-    color.green = 1.0;
-    color.blue = 1.0;
-    color.alpha = 1.0;
-    gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
+  GdkRGBA color;
+  color.red = 1.0;
+  color.green = 1.0;
+  color.blue = 1.0;
+  color.alpha = 1.0;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
     GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/general_menu.c
+++ b/general_menu.c
@@ -159,13 +159,17 @@ void general_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - General");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
-
+#endif
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
   GtkWidget *grid=gtk_grid_new();

--- a/main.c
+++ b/main.c
@@ -20,8 +20,10 @@
 // Define maximum window size. 
 // Standard values 800 and 480: suitable for RaspberryBi 7-inch screen
 
-#define MAX_DISPLAY_WIDTH  800
-#define MAX_DISPLAY_HEIGHT 480
+//#define MAX_DISPLAY_WIDTH  800
+//#define MAX_DISPLAY_HEIGHT 480
+#define MAX_DISPLAY_WIDTH  1366
+#define MAX_DISPLAY_HEIGHT 768
 
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>

--- a/meter_menu.c
+++ b/meter_menu.c
@@ -75,12 +75,17 @@ void meter_menu (GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Meter");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
   GtkWidget *grid=gtk_grid_new();

--- a/midi_menu.c
+++ b/midi_menu.c
@@ -619,12 +619,17 @@ void midi_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/mode_menu.c
+++ b/mode_menu.c
@@ -81,12 +81,17 @@ void mode_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/new_menu.c
+++ b/new_menu.c
@@ -469,12 +469,17 @@ void new_menu()
     gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Menu");
     g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
-    GdkRGBA color;
-    color.red = 1.0;
-    color.green = 1.0;
-    color.blue = 1.0;
-    color.alpha = 1.0;
-    gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
+  GdkRGBA color;
+  color.red = 1.0;
+  color.green = 1.0;
+  color.blue = 1.0;
+  color.alpha = 1.0;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
     GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/new_menu.h
+++ b/new_menu.h
@@ -46,3 +46,8 @@ enum {
 };
 
 extern int active_menu;
+
+#ifdef BKGND
+#include "bkgnd.h"
+#endif
+

--- a/noise_menu.c
+++ b/noise_menu.c
@@ -166,12 +166,17 @@ void noise_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/oc_menu.c
+++ b/oc_menu.c
@@ -122,12 +122,17 @@ g_print("oc_menu: parent=%p\n",parent);
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Open Collector Output");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/pa_menu.c
+++ b/pa_menu.c
@@ -211,12 +211,17 @@ void pa_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - PA Calibration");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/ps_menu.c
+++ b/ps_menu.c
@@ -372,12 +372,17 @@ void ps_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Pure Signal");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/radio_menu.c
+++ b/radio_menu.c
@@ -424,13 +424,17 @@ void radio_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Radio");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
-
+#endif
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
   GtkWidget *grid=gtk_grid_new();

--- a/rigctl_menu.c
+++ b/rigctl_menu.c
@@ -117,12 +117,17 @@ void rigctl_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - RIGCTL");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/rx_menu.c
+++ b/rx_menu.c
@@ -186,13 +186,17 @@ void rx_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
-
+#endif
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
   GtkWidget *grid=gtk_grid_new();

--- a/server_menu.c
+++ b/server_menu.c
@@ -77,12 +77,17 @@ void server_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Server");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/step_menu.c
+++ b/step_menu.c
@@ -67,12 +67,17 @@ void step_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - VFO Step");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/store_menu.c
+++ b/store_menu.c
@@ -123,12 +123,17 @@ void store_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Store");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/test_menu.c
+++ b/test_menu.c
@@ -69,12 +69,17 @@ void test_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Test");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/tx_menu.c
+++ b/tx_menu.c
@@ -229,12 +229,17 @@ void tx_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - Transmit");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/vfo_menu.c
+++ b/vfo_menu.c
@@ -226,12 +226,17 @@ void vfo_menu(GtkWidget *parent,int vfo) {
   gtk_window_set_title(GTK_WINDOW(dialog),title);
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/vox_menu.c
+++ b/vox_menu.c
@@ -155,7 +155,12 @@ void vox_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - VOX");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&white);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 

--- a/xvtr_menu.c
+++ b/xvtr_menu.c
@@ -187,13 +187,17 @@ void xvtr_menu(GtkWidget *parent) {
   gtk_window_set_title(GTK_WINDOW(dialog),"piHPSDR - XVTR");
   g_signal_connect (dialog, "delete_event", G_CALLBACK (delete_event), NULL);
 
+#ifdef BKGND
+  extern GdkRGBA bkgnd_color;
+  gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&bkgnd_color);
+#else
   GdkRGBA color;
   color.red = 1.0;
   color.green = 1.0;
   color.blue = 1.0;
   color.alpha = 1.0;
-
   gtk_widget_override_background_color(dialog,GTK_STATE_FLAG_NORMAL,&color);
+#endif
 
   GtkWidget *content=gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 


### PR DESCRIPTION
built pihpsdr and found all the menus were white text on white background. 
created a Makefile option to use new file bkgnd.h which contains a background color definition which is not 'white'.
changed all the menu code to use the new option when enabled.
note: the discovery menu is unique in that it is similar but not exactly the same override variable as all the others.
also see #28  
