### PR TITLE
protocol: fix PTT relay chatter over network

### DIFF
--- a/new_protocol.c
+++ b/new_protocol.c
@@ -1855,7 +1855,9 @@ static void process_high_priority(unsigned char *buffer) {
     }
 
     if(previous_ptt!=local_ptt) {
-      g_idle_add(ext_mox_update,GINT_TO_POINTER(local_ptt));
+      if(local_ptt || (!mox && !tune)) {
+        g_idle_add(ext_mox_update,GINT_TO_POINTER(local_ptt));
+      }
     }
 }
 

--- a/old_protocol.c
+++ b/old_protocol.c
@@ -879,7 +879,9 @@ static void process_ozy_input_buffer(unsigned char  *buffer) {
     }
 
     if(previous_ptt!=local_ptt) {
-      g_idle_add(ext_mox_update,(gpointer)(long)(local_ptt));
+      if(local_ptt || (!mox && !tune)) {
+        g_idle_add(ext_mox_update,(gpointer)(long)(local_ptt));
+      }
     }
 
     switch((control_in[0]>>3)&0x1F) {


### PR DESCRIPTION
When piHPSDR connects to a Radioberry (or any HPSDR device) over the network, pressing PTT sometimes causes the TX relay to rapidly toggle TX-RX-TX-RX. This does not happen when piHPSDR runs locally on the same host as the SDR hardware.

Both old_protocol.c and new_protocol.c read back the PTT state from incoming hardware packets and call ext_mox_update() whenever it changes. Over the network, there is a window between sending MOX=1 and receiving the hardware's updated PTT=1 response. During this window, stale packets with PTT=0 arrive and trigger ext_mox_update(0), briefly switching back to RX. When the hardware catches up and sends PTT=1, it switches back to TX — causing rapid relay chatter. On localhost this race is masked by near-zero latency.